### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/authmodules/apache2/privacyidea_apache.py
+++ b/authmodules/apache2/privacyidea_apache.py
@@ -55,7 +55,7 @@ SALT_SIZE = 10
 
 def check_password(environ, username, password):
     PRIVACYIDEA, REDIS, SSLVERIFY = _get_config()
-    syslog.syslog(syslog.LOG_DEBUG, "Authentication with %s, %s, %s" % (
+    syslog.syslog(syslog.LOG_DEBUG, "Authentication with {0!s}, {1!s}, {2!s}".format(
         PRIVACYIDEA, REDIS, SSLVERIFY))
     r_value = UNAUTHORIZED
     rd = redis.Redis(REDIS)
@@ -84,7 +84,7 @@ def check_password(environ, username, password):
                 # requests < 1.0
                 json_response = response.json
                 syslog.syslog(syslog.LOG_DEBUG, "requests < 1.0")
-                syslog.syslog(syslog.LOG_DEBUG, "%s" % traceback.format_exc())
+                syslog.syslog(syslog.LOG_DEBUG, "{0!s}".format(traceback.format_exc()))
 
             if json_response.get("result", {}).get("value"):
                 rd.setex(key, _generate_digest(password), seconds)
@@ -105,7 +105,7 @@ def _generate_digest(password):
 
 
 def _generate_key(username, environ):
-    key = "%s+%s+%s+%s" % (environ.get("SERVER_NAME", ""),
+    key = "{0!s}+{1!s}+{2!s}+{3!s}".format(environ.get("SERVER_NAME", ""),
                            environ.get("SERVER_PORT", ""),
                            environ.get("DOCUMENT_ROOT", ""),
                            username)
@@ -135,7 +135,7 @@ def _get_config():
             SSLVERIFY = False
         REDIS = config_file.get("DEFAULT", "redis") or DEFAULT_REDIS
     except ConfigParser.NoOptionError as exx:
-        syslog.syslog(syslog.LOG_ERR, "%s" % exx)
-    syslog.syslog(syslog.LOG_DEBUG, "Reading configuration %s, %s, %s" % (
+        syslog.syslog(syslog.LOG_ERR, "{0!s}".format(exx))
+    syslog.syslog(syslog.LOG_DEBUG, "Reading configuration {0!s}, {1!s}, {2!s}".format(
         PRIVACYIDEA, REDIS, SSLVERIFY))
     return PRIVACYIDEA, REDIS, SSLVERIFY

--- a/migrations/versions/4f32a4e1bf33_.py
+++ b/migrations/versions/4f32a4e1bf33_.py
@@ -266,7 +266,7 @@ def create_update_token_table():
             elif reso[3] == "SQLIdResolver":
                 resolvertype = "sqlresolver"
             else:
-                print("Error: Unknown resolvertype: %s" % reso[3])
+                print("Error: Unknown resolvertype: {0!s}".format(reso[3]))
                 resolvertype = "FIXME"
         if ot.privacyIDEATokenType.lower() == "hmac":
             tokentype = "hotp"
@@ -326,7 +326,7 @@ def create_resolver_config():
 
     # Read Passwd resolver like privacyidea.passwdresolver.*.name
     for resolvertype in ["passwdresolver", "ldapresolver", "sqlresolver"]:
-        print("processing %s" % resolvertype)
+        print("processing {0!s}".format(resolvertype))
         resolvers = {}
         configs = session.query(Config_old).filter(
             Config_old.Key.like("privacyidea." + resolvertype + ".%"))
@@ -408,7 +408,7 @@ def create_realms():
         realmname = realm.Key.split(".")[-1]
         print(realmname)
         resolver_list = [x.split(".")[-1] for x in realm.Value.split(",")]
-        print("   with resolvers: %s" % resolver_list)
+        print("   with resolvers: {0!s}".format(resolver_list))
         for resolvername in resolver_list:
             try:
                 res_id = session.query(Resolver).\

--- a/privacyidea/api/auth.py
+++ b/privacyidea/api/auth.py
@@ -82,7 +82,7 @@ def before_request():
                         "client": g.client_ip,
                         "client_user_agent": request.user_agent.browser,
                         "privacyidea_server": privacyidea_server,
-                        "action": "%s %s" % (request.method, request.url_rule),
+                        "action": "{0!s} {1!s}".format(request.method, request.url_rule),
                         "action_detail": "",
                         "info": ""})
     request.all_data = get_all_params(request.values, request.data)

--- a/privacyidea/api/before_after.py
+++ b/privacyidea/api/before_after.py
@@ -112,7 +112,7 @@ def before_request():
                         "client": g.client_ip,
                         "client_user_agent": request.user_agent.browser,
                         "privacyidea_server": privacyidea_server,
-                        "action": "%s %s" % (request.method, request.url_rule),
+                        "action": "{0!s} {1!s}".format(request.method, request.url_rule),
                         "action_detail": "",
                         "info": ""})
 

--- a/privacyidea/api/caconnector.py
+++ b/privacyidea/api/caconnector.py
@@ -50,7 +50,7 @@ def get_caconnector_api(name=None):
     """
     returns a json list of the available applications
     """
-    g.audit_object.log({"detail": "%s" % name})
+    g.audit_object.log({"detail": "{0!s}".format(name)})
     role = g.logged_in_user.get("role")
     res = get_caconnector_list(filter_caconnector_name=name,
                                return_config=(role == "admin"))
@@ -68,7 +68,7 @@ def save_caconnector_api(name=None):
     """
     param = request.all_data
     param["caconnector"] = name
-    g.audit_object.log({"detail": "%s" % name})
+    g.audit_object.log({"detail": "{0!s}".format(name)})
     res = save_caconnector(param)
     g.audit_object.log({"success": True})
     return send_result(res)
@@ -82,7 +82,7 @@ def delete_caconnector_api(name=None):
     """
     returns a json list of the available applications
     """
-    g.audit_object.log({"detail": "%s" % name})
+    g.audit_object.log({"detail": "{0!s}".format(name)})
     res = delete_caconnector(name)
     g.audit_object.log({"success": True})
     return send_result(res)

--- a/privacyidea/api/lib/prepolicy.py
+++ b/privacyidea/api/lib/prepolicy.py
@@ -119,7 +119,7 @@ def init_random_pin(request=None, action=None):
                                                unique=True)
 
     if len(pin_pols) == 1:
-        log.debug("Creating random OTP PIN with length %s" % pin_pols[0])
+        log.debug("Creating random OTP PIN with length {0!s}".format(pin_pols[0]))
         request.all_data["pin"] = generate_password(size=int(pin_pols[0]))
 
         # handle the PIN
@@ -130,7 +130,7 @@ def init_random_pin(request=None, action=None):
         # We can have more than one pin handler policy. So we can process the
         #  PIN in several ways!
         for handle_pol in handle_pols:
-            log.debug("Handle the random PIN with the class %s" % handle_pol)
+            log.debug("Handle the random PIN with the class {0!s}".format(handle_pol))
             packageName = ".".join(handle_pol.split(".")[:-1])
             className = handle_pol.split(".")[-1:][0]
             mod = __import__(packageName, globals(), locals(), [className])
@@ -194,13 +194,13 @@ def check_otp_pin(request=None, action=None):
 
         if len(pol_minlen) == 1 and len(pin) < int(pol_minlen[0]):
             # check the minimum length requirement
-            raise PolicyError("The minimum OTP PIN length is %s" %
-                              pol_minlen[0])
+            raise PolicyError("The minimum OTP PIN length is {0!s}".format(
+                              pol_minlen[0]))
 
         if len(pol_maxlen) == 1 and len(pin) > int(pol_maxlen[0]):
             # check the maximum length requirement
-            raise PolicyError("The maximum OTP PIN length is %s" %
-                              pol_minlen[0])
+            raise PolicyError("The maximum OTP PIN length is {0!s}".format(
+                              pol_minlen[0]))
 
         if len(pol_contents) == 1:
             # check the contents requirement
@@ -218,11 +218,11 @@ def check_otp_pin(request=None, action=None):
                 pol_contents = pol_contents[1:]
             #  TODO implement grouping and substraction
             if "c" in pol_contents[0] and not re.search(chars, pin):
-                raise PolicyError("Missing character in PIN: %s" % chars)
+                raise PolicyError("Missing character in PIN: {0!s}".format(chars))
             if "n" in pol_contents[0] and not re.search(digits, pin):
-                raise PolicyError("Missing character in PIN: %s" % digits)
+                raise PolicyError("Missing character in PIN: {0!s}".format(digits))
             if "s" in pol_contents[0] and not re.search(special, pin):
-                raise PolicyError("Missing character in PIN: %s" % special)
+                raise PolicyError("Missing character in PIN: {0!s}".format(special))
 
     return True
 
@@ -481,7 +481,7 @@ def mangle(request=None, action=None):
         mangle_key, search, replace, _rest = mangle_pol_action.split("/", 3)
         mangle_value = request.all_data.get(mangle_key)
         if mangle_value:
-            log.debug("mangling authentication data: %s" % mangle_key)
+            log.debug("mangling authentication data: {0!s}".format(mangle_key))
             request.all_data[mangle_key] = re.sub(search, replace,
                                                   mangle_value)
     return True
@@ -620,7 +620,7 @@ def check_token_init(request=None, action=None):
         scope = SCOPE.USER
         admin_realm = None
     tokentype = params.get("type", "HOTP")
-    action = "enroll%s" % tokentype.upper()
+    action = "enroll{0!s}".format(tokentype.upper())
     action = policy_object.get_policies(action=action,
                                         user=username,
                                         realm=params.get("realm"),
@@ -654,7 +654,7 @@ def check_external(request=None, action="init"):
             module = importlib.import_module(module_name)
             function_name = module_func.split(".")[-1]
     except Exception as exx:
-        log.error("Error importing external check function: %s" % exx)
+        log.error("Error importing external check function: {0!s}".format(exx))
 
     # Import of function was successful
     if function_name:

--- a/privacyidea/api/lib/utils.py
+++ b/privacyidea/api/lib/utils.py
@@ -62,7 +62,7 @@ def get_version():
     self service portal.
     """
     version = get_version_number()
-    return "privacyIDEA %s" % version
+    return "privacyIDEA {0!s}".format(version)
 
 
 def getParam(param, key, optional=True, default=None):
@@ -89,7 +89,7 @@ def getParam(param, key, optional=True, default=None):
     elif default:
         ret = default
     elif not optional:
-        raise ParameterError("Missing parameter: %r" % key, id=905)
+        raise ParameterError("Missing parameter: {0!r}".format(key), id=905)
 
     return ret
 
@@ -186,11 +186,11 @@ def send_csv_result(obj, data_key="tokens",
     """
     delim = "'"
     content_type = "application/force-download"
-    headers = {'Content-disposition': 'attachment; filename=%s' % filename}
+    headers = {'Content-disposition': 'attachment; filename={0!s}'.format(filename)}
     output = u""
     # Do the header
     for k, _v in obj.get(data_key, {})[0].items():
-        output += "%s%s%s, " % (delim, k, delim)
+        output += "{0!s}{1!s}{2!s}, ".format(delim, k, delim)
     output += "\n"
 
     # Do the data
@@ -200,7 +200,7 @@ def send_csv_result(obj, data_key="tokens",
                 value = val.replace("\n", " ")
             else:
                 value = val
-            output += "%s%s%s, " % (delim, value, delim)
+            output += "{0!s}{1!s}{2!s}, ".format(delim, value, delim)
         output += "\n"
 
     return Response(output, mimetype=content_type)
@@ -232,7 +232,7 @@ def get_all_params(param, body):
         for k, v in json_data.items():
             return_param[k] = v
     except Exception as exx:
-        log.debug("Can not get param: %s" % exx)
+        log.debug("Can not get param: {0!s}".format(exx))
 
     return return_param
 
@@ -273,11 +273,11 @@ def verify_auth_token(auth_token, required_role=None):
         r = jwt.decode(auth_token, current_app.secret_key)
     except jwt.DecodeError as err:
         raise AuthError("Authentication failure",
-                        "error during decoding your token: %s" % err,
+                        "error during decoding your token: {0!s}".format(err),
                         status=401)
     except jwt.ExpiredSignature as err:
         raise AuthError("Authentication failure",
-                        "Your token has expired: %s" % err,
+                        "Your token has expired: {0!s}".format(err),
                         status=401)
     if required_role and r.get("role") not in required_role:
         # If we require a certain role like "admin", but the users role does

--- a/privacyidea/api/machine.py
+++ b/privacyidea/api/machine.py
@@ -117,7 +117,7 @@ def list_machines_api():
     # so we need to convert the Machine Object to dict
     machines = [mobject.get_dict() for mobject in machines]
     g.audit_object.log({'success': True,
-                        'info': "hostname: %s, ip: %s" % (hostname, ip)})
+                        'info': "hostname: {0!s}, ip: {1!s}".format(hostname, ip)})
     
     return send_result(machines)
 
@@ -173,7 +173,7 @@ def attach_token_api():
                              options=options)
 
     g.audit_object.log({'success': True,
-                        'info': "serial: %s, application: %s" % (serial,
+                        'info': "serial: {0!s}, application: {1!s}".format(serial,
                                                                  application)})
 
     return send_result(mt_object.id)
@@ -211,7 +211,7 @@ def detach_token_api(serial, machineid, resolver, application):
                      machine_id=machineid, resolver_name=resolver)
 
     g.audit_object.log({'success': True,
-                        'info': "serial: %s, application: %s" % (serial,
+                        'info': "serial: {0!s}, application: {1!s}".format(serial,
                                                                  application)})
 
     return send_result(r)
@@ -249,7 +249,7 @@ def list_machinetokens_api():
                                   resolver_name=resolver)
 
     g.audit_object.log({'success': True,
-                        'info': "serial: %s, hostname: %s" % (serial,
+                        'info': "serial: {0!s}, hostname: {1!s}".format(serial,
                                                               hostname)})
     return send_result(res)
 
@@ -302,7 +302,7 @@ def set_option_api():
                       key=k)
 
     g.audit_object.log({'success': True,
-                        'info': "serial: %s, application: %s" % (serial,
+                        'info': "serial: {0!s}, application: {1!s}".format(serial,
                                                                  application)})
 
     return send_result({"added": o_add, "deleted": o_del})
@@ -365,7 +365,7 @@ def get_auth_items_api(application=None):
                          application=application, challenge=challenge,
                          filter_param=filter_param)
     g.audit_object.log({'success': True,
-                        'info': "host: %s, application: %s" % (hostname,
+                        'info': "host: {0!s}, application: {1!s}".format(hostname,
                                                                application)})
     return send_result(ret)
 

--- a/privacyidea/api/policy.py
+++ b/privacyidea/api/policy.py
@@ -180,11 +180,11 @@ def set_policy_api(name=None):
     admin_realm = getParam(param, "adminrealm", optional)
 
     g.audit_object.log({'action_detail': name,
-                        'info': "%s" % param})
+                        'info': "{0!s}".format(param)})
     ret = set_policy(name=name, scope=scope, action=action, realm=realm,
                      resolver=resolver, user=user, client=client,
                      active=active or True, adminrealm=admin_realm)
-    log.debug("policy %s successfully saved." % name)
+    log.debug("policy {0!s} successfully saved.".format(name))
     string = "setPolicy " + name
     res[string] = ret
     g.audit_object.log({"success": True})
@@ -263,8 +263,7 @@ def get_policy(name=None, export=None):
 
     P = g.policy_object
     if not export:
-        log.debug("retrieving policy name: %s, realm: %s, scope: %s"
-                  % (name, realm, scope))
+        log.debug("retrieving policy name: {0!s}, realm: {1!s}, scope: {2!s}".format(name, realm, scope))
 
         pol = P.get_policies(name=name, realm=realm, scope=scope, active=active)
         ret = send_result(pol)
@@ -277,8 +276,7 @@ def get_policy(name=None, export=None):
         ret = response
 
     g.audit_object.log({"success": True,
-                        'info': "name = %s, realm = %s, scope = %s" %
-                       (name, realm, scope)})
+                        'info': "name = {0!s}, realm = {1!s}, scope = {2!s}".format(name, realm, scope)})
     return ret
 
 
@@ -389,13 +387,13 @@ def import_policy_api(filename=None):
         file_contents = policy_file
 
     if file_contents == "":
-        log.error("Error loading/importing policy file. file %s empty!" %
-                  filename)
+        log.error("Error loading/importing policy file. file {0!s} empty!".format(
+                  filename))
         raise ParameterError("Error loading policy. File empty!")
 
     policy_num = import_policies(file_contents=file_contents)
     g.audit_object.log({"success": True,
-                        'info': "imported %d policies from file %s" % (
+                        'info': "imported {0:d} policies from file {1!s}".format(
                             policy_num, filename)})
 
     return send_result(policy_num)
@@ -481,7 +479,7 @@ def check_policy_api():
         policy_names = []
         for pol in policies:
             policy_names.append(pol.get("name"))
-        g.audit_object.log({'info': "allowed by policy %s" % policy_names})
+        g.audit_object.log({'info': "allowed by policy {0!s}".format(policy_names)})
     else:
         res["allowed"] = False
         res["info"] = "No policies found"

--- a/privacyidea/api/realm.py
+++ b/privacyidea/api/realm.py
@@ -139,7 +139,7 @@ def set_realm_api(realm=None):
         Resolvers = resolvers.split(',')
     (added, failed) = set_realm(realm, Resolvers, priority=priority)
     g.audit_object.log({'success': len(added) == len(Resolvers),
-                        'info':  "realm: %r, resolvers: %r" % (realm,
+                        'info':  "realm: {0!r}, resolvers: {1!r}".format(realm,
                                                                resolvers)})
     return send_result({"added": added,
                         "failed": failed})

--- a/privacyidea/api/recover.py
+++ b/privacyidea/api/recover.py
@@ -60,7 +60,7 @@ def get_recover_code():
     email = getParam(param, "email", required)
     r = create_recoverycode(user_obj, email, base_url=request.base_url)
     g.audit_object.log({"success": r,
-                        "info": "%s" % user_obj})
+                        "info": "{0!s}".format(user_obj)})
     return send_result(r)
 
 
@@ -85,5 +85,5 @@ def reset_password():
         # set password
         r = user_obj.update_user_info({"password": password})
         g.audit_object.log({"success": r,
-                            "info": "%s" % user_obj})
+                            "info": "{0!s}".format(user_obj)})
     return send_result(r)

--- a/privacyidea/api/register.py
+++ b/privacyidea/api/register.py
@@ -162,17 +162,17 @@ def register_post():
     # Send the registration key via email
     email_sent = send_email_identifier(smtpconfig, email,
                                        "Your privacyIDEA registration",
-                                       "Your registration token is %s" %
-                                       registration_key)
+                                       "Your registration token is {0!s}".format(
+                                       registration_key))
     if not email_sent:
-        log.warning("Failed to send registration email to %s" % email)
+        log.warning("Failed to send registration email to {0!s}".format(email))
         # delete registration token
         token.delete()
         # delete user
         user.delete()
         raise RegistrationError("Failed to send email!")
 
-    log.debug("Registration email sent to %s" % email)
+    log.debug("Registration email sent to {0!s}".format(email))
 
     g.audit_object.log({"success": email_sent})
     return send_result(email_sent)

--- a/privacyidea/api/system.py
+++ b/privacyidea/api/system.py
@@ -195,7 +195,7 @@ def set_config():
             desc = getParam(param, key + ".desc", optional)
             res = set_privacyidea_config(key, value, typ, desc)
             result[key] = res
-            g.audit_object.add_to_log({"info": "%s=%s, " % (key, value)})
+            g.audit_object.add_to_log({"info": "{0!s}={1!s}, ".format(key, value)})
     g.audit_object.log({"success": True})
     return send_result(result)
 
@@ -227,7 +227,7 @@ def set_default():
             "DefaultOtpLen",
             "DefaultResetFailCount"]
     
-    description = "parameters are: %s" % ", ".join(keys)
+    description = "parameters are: {0!s}".format(", ".join(keys))
     param = getLowerParams(request.all_data)
     result = {}
     for k in keys:
@@ -236,13 +236,13 @@ def set_default():
             res = set_privacyidea_config(k, value)
             result[k] = res
             g.audit_object.log({"success": True})
-            g.audit_object.add_to_log({"info": "%s=%s, " % (k, value)})
+            g.audit_object.add_to_log({"info": "{0!s}={1!s}, ".format(k, value)})
 
     if not result:
         log.warning("Failed saving config. Could not find any "
                     "known parameter. %s"
                     % description)
-        raise ParameterError("Usage: %s" % description, id=77)
+        raise ParameterError("Usage: {0!s}".format(description), id=77)
     
     return send_result(result)
 

--- a/privacyidea/api/token.py
+++ b/privacyidea/api/token.py
@@ -303,7 +303,7 @@ def list_api():
     if realm:
         if realm in filterRealm or '*' in filterRealm:
             filterRealm = [realm]
-    g.audit_object.log({'info': "realm: %s" % (filterRealm)})
+    g.audit_object.log({'info': "realm: {0!s}".format((filterRealm))})
 
     # get list of tokens as a dictionary
     tokens = get_tokens_paginate(serial=serial, realm=realm, page=page,
@@ -646,21 +646,21 @@ def set_api(serial=None):
 
     if count_auth_success_max is not None:
         g.audit_object.add_to_log({'action_detail':
-                                       "count_auth_success_max=%r, " %
-                                       count_auth_success_max})
+                                       "count_auth_success_max={0!r}, ".format(
+                                       count_auth_success_max)})
         res += set_count_auth(serial, count_auth_success_max, user=user,
                               max=True, success=True)
 
     if validity_period_end is not None:
         g.audit_object.add_to_log({'action_detail':
-                                       "validity_period_end=%r, " %
-                                       validity_period_end})
+                                       "validity_period_end={0!r}, ".format(
+                                       validity_period_end)})
         res += set_validity_period_end(serial, user, validity_period_end)
 
     if validity_period_start is not None:
         g.audit_object.add_to_log({'action_detail':
-                                       "validity_period_start=%r, " %
-                                       validity_period_start})
+                                       "validity_period_start={0!r}, ".format(
+                                       validity_period_start)})
         res += set_validity_period_start(serial, user, validity_period_start)
 
     g.audit_object.log({"success": True})
@@ -753,13 +753,12 @@ def loadtokens_api(filename=None):
         file_contents = token_file
 
     if file_contents == "":
-        log.error("Error loading/importing token file. file %s empty!" %
-                  filename)
+        log.error("Error loading/importing token file. file {0!s} empty!".format(
+                  filename))
         raise ParameterError("Error loading token file. File empty!")
 
     if file_type not in known_types:
-        log.error("Unknown file type: >>%s<<. We only know the types: %s" %
-                  (file_type, ', '.join(known_types)))
+        log.error("Unknown file type: >>{0!s}<<. We only know the types: {1!s}".format(file_type, ', '.join(known_types)))
         raise TokenAdminError("Unknown file type: >>%s<<. We only know the "
                               "types: %s" % (file_type,
                                              ', '.join(known_types)))
@@ -778,9 +777,9 @@ def loadtokens_api(filename=None):
     # Now import the Tokens from the dictionary
     ret = ""
     for serial in TOKENS:
-        log.debug("importing token %s" % TOKENS[serial])
+        log.debug("importing token {0!s}".format(TOKENS[serial]))
 
-        log.info("initialize token. serial: %s, realm: %s" % (serial,
+        log.info("initialize token. serial: {0!s}, realm: {1!s}".format(serial,
                                                               tokenrealms))
 
         init_param = {'serial': serial,
@@ -801,7 +800,7 @@ def loadtokens_api(filename=None):
 
         init_token(init_param, tokenrealms=tokenrealms)
 
-    g.audit_object.log({'info': "%s, %s (imported: %i)" % (file_type,
+    g.audit_object.log({'info': "{0!s}, {1!s} (imported: {2:d})".format(file_type,
                                                            token_file,
                                                            len(TOKENS)),
                         'serial': ', '.join(TOKENS.keys())})
@@ -878,7 +877,7 @@ def lost_api(serial=None):
     if userobj:
         toks = get_tokens(serial=serial, user=userobj)
         if not toks:
-            raise TokenAdminError("The user %s does not own the token %s" % (
+            raise TokenAdminError("The user {0!s} does not own the token {1!s}".format(
                 userobj, serial))
 
     options = {"g": g,
@@ -923,11 +922,11 @@ def get_serial_by_otp_api(otp=None):
         assigned = True
 
     tokenobj_list = get_tokens(tokentype=ttype,
-                               serial="*%s*" % serial_substr,
+                               serial="*{0!s}*".format(serial_substr),
                                assigned=assigned)
     serial = get_serial_by_otp(tokenobj_list, otp=otp, window=window)
 
     g.audit_object.log({"success": True,
-                        "info": "get %s by OTP" % serial})
+                        "info": "get {0!s} by OTP".format(serial)})
 
     return send_result({"serial": serial})

--- a/privacyidea/api/ttype.py
+++ b/privacyidea/api/ttype.py
@@ -74,7 +74,7 @@ def before_request():
                         "client": g.client_ip,
                         "client_user_agent": request.user_agent.browser,
                         "privacyidea_server": privacyidea_server,
-                        "action": "%s %s" % (request.method, request.url_rule),
+                        "action": "{0!s} {1!s}".format(request.method, request.url_rule),
                         "info": ""})
 
 
@@ -116,5 +116,5 @@ def token(ttype=None):
     if res[0] == "json":
         return jsonify(res[1])
     elif res[0] in ["html", "plain"]:
-        return Response(res[1], mimetype="text/%s" % res[0])
+        return Response(res[1], mimetype="text/{0!s}".format(res[0]))
 

--- a/privacyidea/api/user.py
+++ b/privacyidea/api/user.py
@@ -99,7 +99,7 @@ def get_users():
     users = get_user_list(request.all_data)
 
     g.audit_object.log({'success': True,
-                        'info': "realm: %s" % realm})
+                        'info': "realm: {0!s}".format(realm)})
     
     return send_result(users)
 
@@ -127,7 +127,7 @@ def delete_user(resolvername=None, username=None):
     user_obj = User(login=username, resolver=resolvername)
     res = user_obj.delete()
     g.audit_object.log({"success": res,
-                        "info": "%s" % user_obj})
+                        "info": "{0!s}".format(user_obj)})
     return send_result(res)
 
 
@@ -164,7 +164,7 @@ def create_user_api():
     resolvername = getParam(request.all_data, "resolver", optional=False)
     r = create_user(resolvername, attributes)
     g.audit_object.log({"success": True,
-                        "info": "%s: %s/%s" % (r, username, resolvername)})
+                        "info": "{0!s}: {1!s}/{2!s}".format(r, username, resolvername)})
     return send_result(r)
 
 
@@ -205,7 +205,7 @@ def update_user():
     user_obj = User(login=username, resolver=resolvername)
     r = user_obj.update_user_info(attributes)
     g.audit_object.log({"success": True,
-                        "info": "%s: %s/%s" % (r, username, resolvername)})
+                        "info": "{0!s}: {1!s}/{2!s}".format(r, username, resolvername)})
     return send_result(r)
 
 

--- a/privacyidea/api/validate.py
+++ b/privacyidea/api/validate.py
@@ -102,7 +102,7 @@ def before_request():
                         "client": g.client_ip,
                         "client_user_agent": request.user_agent.browser,
                         "privacyidea_server": privacyidea_server,
-                        "action": "%s %s" % (request.method, request.url_rule),
+                        "action": "{0!s} {1!s}".format(request.method, request.url_rule),
                         "info": ""})
 
 

--- a/privacyidea/app.py
+++ b/privacyidea/app.py
@@ -102,12 +102,12 @@ def create_app(config_name="development",
     :rtype: App object
     """
     if not silent:
-        print("The configuration name is: %s" % config_name)
+        print("The configuration name is: {0!s}".format(config_name))
     if os.environ.get(ENV_KEY):
         config_file = os.environ[ENV_KEY]
     if not silent:
-        print("Additional configuration can be read from the file %s" %
-              config_file)
+        print("Additional configuration can be read from the file {0!s}".format(
+              config_file))
     app = Flask(__name__, static_folder="static",
                 template_folder="static/templates")
     if config_name:
@@ -120,7 +120,7 @@ def create_app(config_name="development",
     except IOError:
         sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
         sys.stderr.write("  WARNING: privacyidea create_app has no access\n")
-        sys.stderr.write("  to %s!\n" % config_file)
+        sys.stderr.write("  to {0!s}!\n".format(config_file))
         sys.stderr.write("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n")
 
     # Try to load the file, that was specified in the environment variable
@@ -160,20 +160,20 @@ def create_app(config_name="development",
         if os.path.isfile(log_config_file):
             logging.config.fileConfig(log_config_file)
             if not silent:
-                print("Reading Logging settings from %s" % log_config_file)
+                print("Reading Logging settings from {0!s}".format(log_config_file))
         else:
             raise Exception("The config file specified in PI_LOGCONFIG does "
                             "not exist.")
     except Exception as exx:
-        sys.stderr.write("%s\n" % exx)
+        sys.stderr.write("{0!s}\n".format(exx))
         sys.stderr.write("Could not use PI_LOGCONFIG. "
                          "Using PI_LOGLEVEL and PI_LOGFILE.\n")
         level = app.config.get("PI_LOGLEVEL", logging.DEBUG)
         # If there is another logfile in pi.cfg we use this.
         logfile = app.config.get("PI_LOGFILE")
         if logfile:
-            sys.stderr.write("Using PI_LOGLEVEL %s.\n" % level)
-            sys.stderr.write("Using PI_LOGFILE %s.\n" % logfile)
+            sys.stderr.write("Using PI_LOGLEVEL {0!s}.\n".format(level))
+            sys.stderr.write("Using PI_LOGFILE {0!s}.\n".format(logfile))
             PI_LOGGING_CONFIG["handlers"]["file"]["filename"] = logfile
             PI_LOGGING_CONFIG["handlers"]["file"]["level"] = level
             PI_LOGGING_CONFIG["loggers"]["privacyidea"]["level"] = level

--- a/privacyidea/lib/applications/base.py
+++ b/privacyidea/lib/applications/base.py
@@ -42,8 +42,7 @@ def get_machine_application_class_list():
     modules = [f.split(".")[0] for f in files if f.endswith(".py") and f !=
                "__init__.py"]
     for module in modules:
-        class_list.append("privacyidea.lib.applications.%s.MachineApplication"
-                          % module)
+        class_list.append("privacyidea.lib.applications.{0!s}.MachineApplication".format(module))
     return class_list
 
 
@@ -160,11 +159,11 @@ def get_application_types():
     for f in files:
         if f not in ["base", "__init__"]:
             try:
-                mod = import_module("privacyidea.lib.applications.%s" % f)
+                mod = import_module("privacyidea.lib.applications.{0!s}".format(f))
                 name = mod.MachineApplication.application_name
                 options = mod.MachineApplication.get_options()
                 ret[name] = {"options": options}
             except Exception as exx:
-                log.info("Can not get application type: %s" % exx)
+                log.info("Can not get application type: {0!s}".format(exx))
 
     return ret

--- a/privacyidea/lib/apps.py
+++ b/privacyidea/lib/apps.py
@@ -68,7 +68,7 @@ def create_motp_url(key, user=None, realm=None, serial=""):
     label = label[0:allowed_label_len]
     url_label = quote(label)
     
-    return "motp://privacyidea:%s?secret=%s" % (url_label, otpkey)
+    return "motp://privacyidea:{0!s}?secret={1!s}".format(url_label, otpkey)
 
 
 @log_with(log)
@@ -97,11 +97,11 @@ def create_google_authenticator_url(key=None, user=None,
     # also strip the padding =, as it will get problems with the google app.
     otpkey = base64.b32encode(key_bin).strip('=')
 
-    base_len = len("otpauth://%s/?secret=%s&counter=1" % (tokentype, otpkey))
+    base_len = len("otpauth://{0!s}/?secret={1!s}&counter=1".format(tokentype, otpkey))
     max_len = 119
     allowed_label_len = max_len - base_len
-    log.debug("we have got %s characters left for the token label" %
-              str(allowed_label_len))
+    log.debug("we have got {0!s} characters left for the token label".format(
+              str(allowed_label_len)))
     label = tokenlabel.replace("<s>",
                                serial).replace("<u>",
                                                user).replace("<r>", realm)
@@ -110,7 +110,7 @@ def create_google_authenticator_url(key=None, user=None,
     url_label = quote(label)
 
     if hash_algo.lower() != "sha1":
-        hash_algo = "algorithm=%s&" % hash_algo
+        hash_algo = "algorithm={0!s}&".format(hash_algo)
     else:
         # If the hash_algo is SHA1, we do not add it to the QR code to keep
         # the QR code simpler
@@ -137,7 +137,7 @@ def create_oathtoken_url(otpkey=None, user=None, realm=None,
                                                user).replace("<r>", realm)
     url_label = quote(label)
 
-    url = "oathtoken:///addToken?name=%s&lockdown=true&key=%s%s" % (
+    url = "oathtoken:///addToken?name={0!s}&lockdown=true&key={1!s}{2!s}".format(
                                                                   url_label,
                                                                   otpkey,
                                                                   timebased

--- a/privacyidea/lib/audit.py
+++ b/privacyidea/lib/audit.py
@@ -70,7 +70,7 @@ def getAuditClass(packageName, className):
     """
     mod = __import__(packageName, globals(), locals(), [className])
     klass = getattr(mod, className)
-    log.debug("klass: %s" % klass)
+    log.debug("klass: {0!s}".format(klass))
     if not hasattr(klass, "log"):  # pragma: no cover
         raise NameError("Audit AttributeError: " + packageName + "." +
                         className + " instance has no attribute 'log'")

--- a/privacyidea/lib/auditmodules/base.py
+++ b/privacyidea/lib/auditmodules/base.py
@@ -119,7 +119,7 @@ class Audit(object):  # pragma: no cover
         :type count: int
         :return:
         """
-        self.audit_data['action_detail'] = "tokennum = %s" % str(count)
+        self.audit_data['action_detail'] = "tokennum = {0!s}".format(str(count))
 
     @log_with(log)
     def read_keys(self, pub, priv):
@@ -142,7 +142,7 @@ class Audit(object):  # pragma: no cover
             self.private = f.read()
             f.close()
         except Exception as e:
-            log.error("Error reading private key %s: (%r)" % (priv, e))
+            log.error("Error reading private key {0!s}: ({1!r})".format(priv, e))
             raise e
 
         try:
@@ -150,7 +150,7 @@ class Audit(object):  # pragma: no cover
             self.public = f.read()
             f.close()
         except Exception as e:
-            log.error("Error reading public key %s: (%r)" % (pub, e))
+            log.error("Error reading public key {0!s}: ({1!r})".format(pub, e))
             raise e
 
     def get_audit_id(self):

--- a/privacyidea/lib/auditmodules/sqlaudit.py
+++ b/privacyidea/lib/auditmodules/sqlaudit.py
@@ -140,7 +140,7 @@ class Audit(AuditBase):
         connect_string = self.config.get("PI_AUDIT_SQL_URI",
                                         self.config.get(
                                             "SQLALCHEMY_DATABASE_URI"))
-        log.debug("using the connect string %s" % connect_string)
+        log.debug("using the connect string {0!s}".format(connect_string))
         self.engine = create_engine(connect_string)
 
         # create a configured "Session" class
@@ -152,7 +152,7 @@ class Audit(AuditBase):
         try:
             metadata.create_all(self.engine)
         except OperationalError as exx:  # pragma: no cover
-            log.info("%r" % exx)
+            log.info("{0!r}".format(exx))
 
     @staticmethod
     def _create_filter(param):
@@ -176,7 +176,7 @@ class Audit(AuditBase):
                     except Exception as exx:
                         # The search_key was no search key but some
                         # bullshit stuff in the param
-                        log.debug("Not a valid searchkey: %s" % exx)
+                        log.debug("Not a valid searchkey: {0!s}".format(exx))
         # Combine them with or to a BooleanClauseList
         filter_condition = and_(*conditions)
         return filter_condition
@@ -250,9 +250,9 @@ class Audit(AuditBase):
                 self.session.merge(le)
                 self.session.commit()
         except Exception as exx:  # pragma: no cover
-            log.error("exception %r" % exx)
-            log.error("DATA: %s" % self.audit_data)
-            log.debug("%s" % traceback.format_exc())
+            log.error("exception {0!r}".format(exx))
+            log.error("DATA: {0!s}".format(self.audit_data))
+            log.debug("{0!s}".format(traceback.format_exc()))
             self.session.rollback()
 
         finally:
@@ -300,8 +300,8 @@ class Audit(AuditBase):
             if id_bef and id_aft:
                 res = True
         except Exception as exx:  # pragma: no cover
-            log.error("exception %r" % exx)
-            log.debug("%s" % traceback.format_exc())
+            log.error("exception {0!r}".format(exx))
+            log.debug("{0!s}".format(traceback.format_exc()))
             # self.session.rollback()
         finally:
             # self.session.close()
@@ -373,7 +373,7 @@ class Audit(AuditBase):
         for le in logentries:
             audit_dict = self.audit_entry_to_dict(le)
             audit_list = audit_dict.values()
-            string_list = ["'%s'" % x for x in audit_list]
+            string_list = ["'{0!s}'".format(x) for x in audit_list]
             yield ",".join(string_list)+"\n"
 
     def get_count(self, search_dict, timedelta=None, success=None):
@@ -444,8 +444,8 @@ class Audit(AuditBase):
                     limit).offset(offset)
                                          
         except Exception as exx:  # pragma: no cover
-            log.error("exception %r" % exx)
-            log.debug("%s" % traceback.format_exc())
+            log.error("exception {0!r}".format(exx))
+            log.debug("{0!s}".format(traceback.format_exc()))
             self.session.rollback()
         finally:
             self.session.close()

--- a/privacyidea/lib/auth.py
+++ b/privacyidea/lib/auth.py
@@ -74,7 +74,7 @@ def list_db_admin():
     print("Name \t email")
     print(30*"=")
     for admin in admins:
-        print("%s \t %s" % (admin.username, admin.email))
+        print("{0!s} \t {1!s}".format(admin.username, admin.email))
 
 
 def get_db_admins():
@@ -83,7 +83,7 @@ def get_db_admins():
 
 
 def delete_db_admin(username):
-    print("Deleting admin %s" % username)
+    print("Deleting admin {0!s}".format(username))
     Admin.query.filter(Admin.username == username).first().delete()
 
 

--- a/privacyidea/lib/caconnector.py
+++ b/privacyidea/lib/caconnector.py
@@ -71,8 +71,7 @@ def save_caconnector(params):
     sanity_name_check(connector_name)
     # check the type
     if connector_type not in get_caconnector_types():
-        raise Exception("connector type : %s not in %s" %
-                        (connector_type, unicode(get_caconnector_types())))
+        raise Exception("connector type : {0!s} not in {1!s}".format(connector_type, unicode(get_caconnector_types())))
 
     # check the name
     connectors = get_caconnector_list(filter_caconnector_name=connector_name)
@@ -268,7 +267,7 @@ def get_caconnector_object(connector_name):
     c_obj_class = get_caconnector_class(c_type)
 
     if c_obj_class is None:
-        log.error("unknown CA connector class %s " % connector_name)
+        log.error("unknown CA connector class {0!s} ".format(connector_name))
     else:
         # create the resolver instance and load the config
         c_obj = c_obj_class(connector_name)

--- a/privacyidea/lib/config.py
+++ b/privacyidea/lib/config.py
@@ -184,12 +184,12 @@ def get_token_class_dict():
                 # We must not process imported classes!
                 if obj.__module__ == module.__name__:
                     try:
-                        class_name = "%s.%s" % (module.__name__, obj.__name__)
+                        class_name = "{0!s}.{1!s}".format(module.__name__, obj.__name__)
                         tokenclass_dict[class_name] = obj
                         if hasattr(obj, 'get_class_type'):
                             tokentype_dict[class_name] = obj.get_class_type()
                     except Exception as e:  # pragma: no cover
-                        log.error("error constructing token_class_dict: %r" % e)
+                        log.error("error constructing token_class_dict: {0!r}".format(e))
 
     return tokenclass_dict, tokentype_dict
 
@@ -294,14 +294,14 @@ def get_machine_resolver_class_dict():
 
     modules = get_machine_resolver_module_list()
     for module in modules:
-        log.debug("module: %s" % module)
+        log.debug("module: {0!s}".format(module))
         for name in dir(module):
             obj = getattr(module, name)
             if inspect.isclass(obj) and \
                     (issubclass(obj, BaseMachineResolver)) and \
                     (obj != BaseMachineResolver):
                 try:
-                    class_name = "%s.%s" % (module.__name__, obj.__name__)
+                    class_name = "{0!s}.{1!s}".format(module.__name__, obj.__name__)
                     resolverclass_dict[class_name] = obj
                     resolvertype_dict[class_name] = obj.type
 
@@ -329,14 +329,14 @@ def get_caconnector_class_dict():
 
     modules = get_caconnector_module_list()
     for module in modules:
-        log.debug("module: %s" % module)
+        log.debug("module: {0!s}".format(module))
         for name in dir(module):
             obj = getattr(module, name)
             if inspect.isclass(obj) and \
                     (issubclass(obj, BaseCAConnector)) and \
                     (obj != BaseCAConnector):
                 try:
-                    class_name = "%s.%s" % (module.__name__, obj.__name__)
+                    class_name = "{0!s}.{1!s}".format(module.__name__, obj.__name__)
                     class_dict[class_name] = obj
                     type_dict[class_name] = obj.connector_type
 
@@ -371,7 +371,7 @@ def get_resolver_class_dict():
     modules = get_resolver_module_list()
     base_class_repr = "privacyidea.lib.resolvers.UserIdResolver.UserIdResolver"
     for module in modules:
-        log.debug("module: %s" % module)
+        log.debug("module: {0!s}".format(module))
         for name in dir(module):
             obj = getattr(module, name)
             # There are other classes like HMAC in the lib.tokens module,
@@ -381,7 +381,7 @@ def get_resolver_class_dict():
                 # We must not process imported classes!
                 # if obj.__module__ == module.__name__:
                 try:
-                    class_name = "%s.%s" % (module.__name__, obj.__name__)
+                    class_name = "{0!s}.{1!s}".format(module.__name__, obj.__name__)
                     resolverclass_dict[class_name] = obj
 
                     prefix = class_name.split('.')[1]
@@ -391,8 +391,7 @@ def get_resolver_class_dict():
                     resolverprefix_dict[class_name] = prefix
 
                 except Exception as e:  # pragma: no cover
-                    log.error("error constructing resolverclass_list: %r"
-                                 % e)
+                    log.error("error constructing resolverclass_list: {0!r}".format(e))
 
     return resolverclass_dict, resolverprefix_dict
 
@@ -418,7 +417,7 @@ def get_resolver_list():
     # TODO: Migration
     # config_modules = config.get("privacyideaResolverModules", '')
     config_modules = None
-    log.debug("%s" % config_modules)
+    log.debug("{0!s}".format(config_modules))
     if config_modules:
         # in the config *.ini files we have some line continuation slashes,
         # which will result in ugly module names, but as they are followed by
@@ -489,7 +488,7 @@ def get_token_list():
     # TODO: Migration
     # config_modules = config.get("privacyideaResolverModules", '')
     config_modules = None
-    log.debug("%s" % config_modules)
+    log.debug("{0!s}".format(config_modules))
     if config_modules:
         # in the config *.ini files we have some line continuation slashes,
         # which will result in ugly module names, but as they are followed by
@@ -514,7 +513,7 @@ def get_token_module_list():
     """
     # def load_resolver_modules
     module_list = get_token_list()
-    log.debug("using the module list: %s" % module_list)
+    log.debug("using the module list: {0!s}".format(module_list))
 
     modules = []
     for mod_name in module_list:
@@ -528,13 +527,12 @@ def get_token_module_list():
         #    modules.append(module)
         #else:
         try:
-            log.debug("import module: %s" % mod_name)
+            log.debug("import module: {0!s}".format(mod_name))
             module = importlib.import_module(mod_name)
             modules.append(module)
         except Exception as exx:  # pragma: no cover
             module = None
-            log.warning('unable to load resolver module : %r (%r)'
-                        % (mod_name, exx))
+            log.warning('unable to load resolver module : {0!r} ({1!r})'.format(mod_name, exx))
 
     return modules
 
@@ -550,7 +548,7 @@ def get_resolver_module_list():
 
     # def load_resolver_modules
     module_list = get_resolver_list()
-    log.debug("using the module list: %s" % module_list)
+    log.debug("using the module list: {0!s}".format(module_list))
 
     modules = []
     for mod_name in module_list:
@@ -558,13 +556,12 @@ def get_resolver_module_list():
             continue
 
         try:
-            log.debug("import module: %s" % mod_name)
+            log.debug("import module: {0!s}".format(mod_name))
             module = importlib.import_module(mod_name)
 
         except Exception as exx:  # pragma: no cover
             module = None
-            log.warning('unable to load resolver module : %r (%r)'
-                        % (mod_name, exx))
+            log.warning('unable to load resolver module : {0!r} ({1!r})'.format(mod_name, exx))
 
         if module is not None:
             modules.append(module)
@@ -587,13 +584,12 @@ def get_caconnector_module_list():
         mod_name = ".".join(mod_name.split(".")[:-1])
         class_name = mod_name.split(".")[-1:]
         try:
-            log.debug("import module: %s" % mod_name)
+            log.debug("import module: {0!s}".format(mod_name))
             module = importlib.import_module(mod_name)
 
         except Exception as exx:  # pragma: no cover
             module = None
-            log.warning('unable to load ca connector module : %r (%r)'
-                        % (mod_name, exx))
+            log.warning('unable to load ca connector module : {0!r} ({1!r})'.format(mod_name, exx))
 
         if module is not None:
             modules.append(module)
@@ -612,19 +608,18 @@ def get_machine_resolver_module_list():
 
     # def load_resolver_modules
     class_list = get_machine_resolver_class_list()
-    log.debug("using the class list: %s" % class_list)
+    log.debug("using the class list: {0!s}".format(class_list))
 
     modules = []
     for class_name in class_list:
         try:
             module_name = ".".join(class_name.split(".")[:-1])
-            log.debug("import module: %s" % module_name)
+            log.debug("import module: {0!s}".format(module_name))
             module = importlib.import_module(module_name)
 
         except Exception as exx:  # pragma: no cover
             module = None
-            log.warning('unable to load machine resolver module : %r (%r)'
-                        % (module_name, exx))
+            log.warning('unable to load machine resolver module : {0!r} ({1!r})'.format(module_name, exx))
 
         if module is not None:
             modules.append(module)

--- a/privacyidea/lib/crypto.py
+++ b/privacyidea/lib/crypto.py
@@ -545,7 +545,7 @@ def get_rand_digit_str(length=16):
         raise ValueError("get_rand_digit_str only works for values > 1")
     clen = int(length / 2.4 + 0.5)
     randd = geturandom(clen)
-    s = "%d" % (int(randd.encode('hex'), 16))
+    s = "{0:d}".format((int(randd.encode('hex'), 16)))
     if len(s) < length:
         s = "0" * (length - len(s)) + s
     elif len(s) > length:
@@ -605,7 +605,7 @@ class Sign(object):
             self.private = f.read()
             f.close()
         except Exception as e:
-            log.error("Error reading private key %s: (%r)" % (private_file, e))
+            log.error("Error reading private key {0!s}: ({1!r})".format(private_file, e))
             raise e
 
         try:
@@ -613,7 +613,7 @@ class Sign(object):
             self.public = f.read()
             f.close()
         except Exception as e:
-            log.error("Error reading public key %s: (%r)" % (public_file, e))
+            log.error("Error reading public key {0!s}: ({1!r})".format(public_file, e))
             raise e
 
     def sign(self, s):
@@ -648,6 +648,6 @@ class Sign(object):
                 hashvalue = HashFunc.new(s)
                 pkcs1_15.new(RSAkey).verify(hashvalue, signature)
         except Exception:  # pragma: no cover
-            log.error("Failed to verify signature: %r" % s)
-            log.debug("%s" % traceback.format_exc())
+            log.error("Failed to verify signature: {0!r}".format(s))
+            log.debug("{0!s}".format(traceback.format_exc()))
         return r

--- a/privacyidea/lib/error.py
+++ b/privacyidea/lib/error.py
@@ -61,11 +61,11 @@ class privacyIDEAError(Exception):
         try:
             res = pstr % (self.id, self.message)
         except Exception as exx:
-            res = u"ERR%d: %r" % (self.id, self.message)
+            res = u"ERR{0:d}: {1!r}".format(self.id, self.message)
         return res
 
     def __repr__(self):
-        ret = '%s(description=%r, id=%d)' % (type(self).__name__,
+        ret = '{0!s}(description={1!r}, id={2:d})'.format(type(self).__name__,
                                              self.message, self.id)
         return ret
 
@@ -84,7 +84,7 @@ class BaseError(Exception):
                 "description": self.description}
         
     def __repr__(self):
-        ret = '%s(error=%r, description=%r, id=%d)' % (type(self).__name__,
+        ret = '{0!s}(error={1!r}, description={2!r}, id={3:d})'.format(type(self).__name__,
                                                        self.error,
                                                        self.description,
                                                        self.status_code)

--- a/privacyidea/lib/importotp.py
+++ b/privacyidea/lib/importotp.py
@@ -75,7 +75,7 @@ class ImportException(Exception):
         self.description = description
 
     def __str__(self):
-        return ('%s' % self.description)
+        return ('{0!s}'.format(self.description))
 
 
 def getTagName(elem):
@@ -116,7 +116,7 @@ def parseOATHcsv(csv):
 
     csv_array = csv.split('\n')
 
-    log.debug("the file contains %i tokens." % len(csv_array))
+    log.debug("the file contains {0:d} tokens.".format(len(csv_array)))
     for line in csv_array:
         l = line.split(',')
         serial = ""
@@ -136,7 +136,7 @@ def parseOATHcsv(csv):
                 if len(key) == 32:
                     hashlib = "sha256"
             else:
-                log.error("the line %s did not contain a hotp key" % line)
+                log.error("the line {0!s} did not contain a hotp key".format(line))
                 continue
 
             # ttype
@@ -154,8 +154,7 @@ def parseOATHcsv(csv):
             if len(l) >= 5:
                 seconds = int(l[4].strip())
 
-            log.debug("read the line |%s|%s|%s|%i %s|%i|" %
-                      (serial, key, ttype, otplen, ocrasuite, seconds))
+            log.debug("read the line |{0!s}|{1!s}|{2!s}|{3:d} {4!s}|{5:d}|".format(serial, key, ttype, otplen, ocrasuite, seconds))
 
             TOKENS[serial] = {'type': ttype,
                               'otpkey': key,
@@ -215,7 +214,7 @@ def parseYubicoCSV(csv):
     TOKENS = {}
     csv_array = csv.split('\n')
 
-    log.debug("the file contains %i tokens." % len(csv_array))
+    log.debug("the file contains {0:d} tokens.".format(len(csv_array)))
     for line in csv_array:
         l = line.split(',')
         serial = ""
@@ -237,7 +236,7 @@ def parseYubicoCSV(csv):
                 if public_id == "":
                     # Usually a "static password" does not have a public ID!
                     # So we would bail out here for static passwords.
-                    log.warning("No public ID in line %r" % line)
+                    log.warning("No public ID in line {0!r}".format(line))
                     continue
 
                 serial_int = int(binascii.hexlify(modhex_decode(public_id)),
@@ -246,7 +245,7 @@ def parseYubicoCSV(csv):
                 if typ.lower() == "yubico otp":
                     ttype = "yubikey"
                     otplen = 32 + len(public_id)
-                    serial = "UBAM%08d_%s" % (serial_int, slot)
+                    serial = "UBAM{0:08d}_{1!s}".format(serial_int, slot)
                     TOKENS[serial] = {'type': ttype,
                                       'otpkey': key,
                                       'otplen': otplen,
@@ -263,7 +262,7 @@ def parseYubicoCSV(csv):
                     '''
                     ttype = "hotp"
                     otplen = 6
-                    serial = "UBOM%08d_%s" % (serial_int, slot)
+                    serial = "UBOM{0:08d}_{1!s}".format(serial_int, slot)
                     TOKENS[serial] = {'type': ttype,
                                       'otpkey': key,
                                       'otplen': otplen,
@@ -283,12 +282,12 @@ def parseYubicoCSV(csv):
                 if l[2].strip() == "0":
                     # HOTP
                     typ = "hotp"
-                    serial = "UBOM%s_%s" % (serial, slot)
+                    serial = "UBOM{0!s}_{1!s}".format(serial, slot)
                     otplen = 6
                 elif l[2].strip() == "":
                     # Static
                     typ = "pw"
-                    serial = "UBSM%s_%s" % (serial, slot)
+                    serial = "UBSM{0!s}_{1!s}".format(serial, slot)
                     key = _create_static_password(key)
                     otplen = len(key)
                     log.warning("We can not enroll a static mode, since we do"
@@ -298,7 +297,7 @@ def parseYubicoCSV(csv):
                 else:
                     # Yubico
                     typ = "yubikey"
-                    serial = "UBAM%s_%s" % (serial, slot)
+                    serial = "UBAM{0!s}_{1!s}".format(serial, slot)
                     public_id = l[1].strip()
                     otplen = 32 + len(public_id)
                 TOKENS[serial] = {'type': typ,
@@ -307,7 +306,7 @@ def parseYubicoCSV(csv):
                                   'description': public_id
                                   }
         else:
-            log.warning("the line %r did not contain a enough values" % line)
+            log.warning("the line {0!r} did not contain a enough values".format(line))
             continue
 
     return TOKENS
@@ -336,7 +335,7 @@ def parseSafeNetXML(xml):
         DESCRIPTION = None
         if getTagName(elem_token) == "Token":
             SERIAL = elem_token.get("serial")
-            log.debug("Found token with serial %s" % SERIAL)
+            log.debug("Found token with serial {0!s}".format(SERIAL))
             for elem_tdata in list(elem_token):
                 tag = getTagName(elem_tdata)
                 if "ProductName" == tag:
@@ -366,8 +365,8 @@ def parseSafeNetXML(xml):
                                       'hashlib': hashlib
                                       }
                 else:
-                    log.error("Found token %s without a element 'Seed'" %
-                              SERIAL)
+                    log.error("Found token {0!s} without a element 'Seed'".format(
+                              SERIAL))
 
     return TOKENS
 
@@ -460,12 +459,12 @@ def parsePSKCdata(xml_data,
         try:
             token["description"] = key_package.deviceinfo.manufacturer.string
         except Exception as exx:
-            log.debug("Can not get manufacturer string %s" % exx)
+            log.debug("Can not get manufacturer string {0!s}".format(exx))
         serial = key["id"]
         try:
             serial = key_package.deviceinfo.serialno.string
         except Exception as exx:
-            log.debug("Can not get serial string from device info %s" % exx)
+            log.debug("Can not get serial string from device info {0!s}".format(exx))
         algo = key["algorithm"]
         token["type"] = algo[-4:].lower()
         parameters = key.algorithmparameters
@@ -488,7 +487,7 @@ def parsePSKCdata(xml_data,
                                      enc_iv, enc_cipher)
                 token["otpkey"] = binascii.hexlify(secret)
         except Exception as exx:
-            log.error("Failed to import tokendata: %s" % exx)
+            log.error("Failed to import tokendata: {0!s}".format(exx))
             log.debug(traceback.format_exc())
             raise ImportException("Failed to import tokendata. Wrong "
                                   "encryption key? %s" % exx)

--- a/privacyidea/lib/machine.py
+++ b/privacyidea/lib/machine.py
@@ -96,7 +96,7 @@ def get_hostname(ip):
         if type(hostname) == list:
             hostname = hostname[0]
     else:
-        raise Exception("There is no machine with IP=%r" % ip)
+        raise Exception("There is no machine with IP={0!r}".format(ip))
     return hostname
 
 
@@ -121,8 +121,7 @@ def get_machine_id(hostname, ip=None):
         resolver_name = machines[0].resolver_name
 
     if machine_id is None:
-        raise Exception("There is no machine with name=%r and IP=%r" %
-                        (hostname, ip))
+        raise Exception("There is no machine with name={0!r} and IP={1!r}".format(hostname, ip))
 
     return machine_id, resolver_name
 

--- a/privacyidea/lib/machineresolver.py
+++ b/privacyidea/lib/machineresolver.py
@@ -76,8 +76,7 @@ def save_resolver(params):
     # check the type
     (class_dict, type_dict) = get_machine_resolver_class_dict()
     if resolvertype not in type_dict.values():
-            raise Exception("machine resolver type : %s not in %s" %
-                            (resolvertype, type_dict.values()))
+            raise Exception("machine resolver type : {0!s} not in {1!s}".format(resolvertype, type_dict.values()))
 
     # check the name
     resolvers = get_resolver_list(filter_resolver_name=resolvername)
@@ -259,8 +258,8 @@ def get_resolver_object(resolvername):
         if r_obj_class is None:  # pragma: no cover
             # This can only happen if a resolver class definition would be
             # removed.
-            log.error("unknown resolver class for type %s " %
-                      resolver.get("type"))
+            log.error("unknown resolver class for type {0!s} ".format(
+                      resolver.get("type")))
         else:
             # create the resolver instance and load the config
             r_obj = r_obj_class(resolvername, resolver.get("data"))

--- a/privacyidea/lib/machines/base.py
+++ b/privacyidea/lib/machines/base.py
@@ -83,9 +83,9 @@ class Machine(object):
         """
         ip = self.ip
         if type(self.ip) == list:
-            ip = ["%s" % i for i in ip]
+            ip = ["{0!s}".format(i) for i in ip]
         elif type(self.ip) == netaddr.IPAddress:
-            ip = "%s" % ip
+            ip = "{0!s}".format(ip)
 
         d = {"hostname": self.hostname,
              "ip": ip,

--- a/privacyidea/lib/machines/hosts.py
+++ b/privacyidea/lib/machines/hosts.py
@@ -69,7 +69,7 @@ class HostsMachineResolver(BaseMachineResolver):
                     # check if machineid, ip or hostname matches a substring
                     if any not in line_id and \
                         len([x for x in line_hostname if any in x]) <= 0 \
-                            and any not in "%s" % line_ip:
+                            and any not in "{0!s}".format(line_ip):
                             # "any" was provided but did not match either
                             # hostname, ip or machine_id
                             continue

--- a/privacyidea/lib/machines/ldap.py
+++ b/privacyidea/lib/machines/ldap.py
@@ -87,28 +87,28 @@ class LdapMachineResolver(BaseMachineResolver):
         if not any:
             if hostname:
                 if substring:
-                    filter += "(%s=*%s*)" % (hostname_attribute, hostname)
+                    filter += "({0!s}=*{1!s}*)".format(hostname_attribute, hostname)
                 else:
-                    filter += "(%s=%s)" % (hostname_attribute, hostname)
+                    filter += "({0!s}={1!s})".format(hostname_attribute, hostname)
             if ip:
                 if substring:
-                    filter += "(%s=*%s*)" % (ip_attribute, ip)
+                    filter += "({0!s}=*{1!s}*)".format(ip_attribute, ip)
                 else:
-                    filter += "(%s=%s)" % (ip_attribute, ip)
+                    filter += "({0!s}={1!s})".format(ip_attribute, ip)
         filter += ")"
         if any:
             # Now we need to extend the search filter
             # like this  (& (&(....)) (|(ip=...)(host=...)) )
             any_filter = "(|"
             if id_attribute:
-                any_filter += "(%s=*%s*)" % (id_attribute, any)
+                any_filter += "({0!s}=*{1!s}*)".format(id_attribute, any)
             if hostname_attribute:
-                any_filter += "(%s=*%s*)" % (hostname_attribute, any)
+                any_filter += "({0!s}=*{1!s}*)".format(hostname_attribute, any)
             if ip_attribute:
-                any_filter += "(%s=*%s*)" % (ip_attribute, any)
+                any_filter += "({0!s}=*{1!s}*)".format(ip_attribute, any)
             any_filter += ")"
 
-            filter = "(&%s%s)" % (filter, any_filter)
+            filter = "(&{0!s}{1!s})".format(filter, any_filter)
 
         return filter
 
@@ -173,8 +173,8 @@ class LdapMachineResolver(BaseMachineResolver):
                                             hostname=machine['hostname'],
                                             ip=machine_ip))
             except Exception as exx:  # pragma: no cover
-                log.error("Error during fetching LDAP objects: %r" % exx)
-                log.debug("%s" % traceback.format_exc())
+                log.error("Error during fetching LDAP objects: {0!r}".format(exx))
+                log.debug("{0!s}".format(traceback.format_exc()))
 
         return machines
 
@@ -196,8 +196,8 @@ class LdapMachineResolver(BaseMachineResolver):
         machine_id = None
         machines = self.get_machines(hostname=hostname, ip=ip)
         if len(machines) > 1:
-            raise Exception("More than one machine found in LDAP resolver %s" %
-                            self.name)
+            raise Exception("More than one machine found in LDAP resolver {0!s}".format(
+                            self.name))
 
         if len(machines) == 1:
             machine_id = machines[0].id
@@ -299,6 +299,6 @@ class LdapMachineResolver(BaseMachineResolver):
             success = True
 
         except Exception as e:
-            desc = "%r" % e
+            desc = "{0!r}".format(e)
 
         return success, desc

--- a/privacyidea/lib/passwordreset.py
+++ b/privacyidea/lib/passwordreset.py
@@ -90,7 +90,7 @@ def create_recoverycode(user, email=None, expiration_seconds=3600,
                                           user.login, user.realm,
                                           recoverycode))
         if not r:
-            raise privacyIDEAError("Failed to send email. %s" % r)
+            raise privacyIDEAError("Failed to send email. {0!s}".format(r))
     else:
         raise ConfigAdminError("Missing configuration "
                                "recovery.identifier.")
@@ -113,7 +113,7 @@ def check_recoverycode(user, recoverycode):
     # delete old entries
     r = PasswordReset.query.filter(and_(PasswordReset.expiration <
                                       datetime.now())).delete()
-    log.debug("%s old password recoverycodes deleted." % r)
+    log.debug("{0!s} old password recoverycodes deleted.".format(r))
     sql_query = PasswordReset.query.filter(and_(PasswordReset.username ==
                                             user.login,
                                                 PasswordReset.realm
@@ -121,10 +121,10 @@ def check_recoverycode(user, recoverycode):
     for pwr in sql_query:
         if verify_with_pepper(pwr.recoverycode, recoverycode):
             recoverycode_valid = True
-            log.debug("Found valid recoverycode for user %s" % user)
+            log.debug("Found valid recoverycode for user {0!s}".format(user))
             # Delete the recovery code, so that it can only be used once!
             r = pwr.delete()
-            log.debug("%s used password recoverycode deleted." % r)
+            log.debug("{0!s} used password recoverycode deleted.".format(r))
 
     return recoverycode_valid
 
@@ -140,14 +140,14 @@ def is_password_reset():
     :return: True or False
     """
     rlist = get_resolver_list(editable=True)
-    log.debug("Number of editable resolvers: %s" % len(rlist))
+    log.debug("Number of editable resolvers: {0!s}".format(len(rlist)))
     Policy = PolicyClass()
     policy_at_all = Policy.get_policies(scope=SCOPE.USER, active=True)
-    log.debug("Policy at all: %s" % policy_at_all)
+    log.debug("Policy at all: {0!s}".format(policy_at_all))
     policy_reset_pw = Policy.get_policies(scope=SCOPE.USER,
                                           action=ACTION.PASSWORDRESET)
-    log.debug("Password reset policy: %s" % policy_reset_pw)
+    log.debug("Password reset policy: {0!s}".format(policy_reset_pw))
     pwreset = (policy_at_all and policy_reset_pw) or not policy_at_all
-    log.debug("Password reset allowed via policy: %s" % pwreset)
+    log.debug("Password reset allowed via policy: {0!s}".format(pwreset))
 
     return bool(rlist and pwreset)

--- a/privacyidea/lib/pinhandling/base.py
+++ b/privacyidea/lib/pinhandling/base.py
@@ -71,8 +71,7 @@ class PinHandler(object):
         :rtype: bool
         """
         # The most simple way of handling a random PIN! ;-)
-        log.info("handling pin %s for token %s of user %s" % (pin, serial,
+        log.info("handling pin {0!s} for token {1!s} of user {2!s}".format(pin, serial,
                                                               user))
-        log.info("The token was enrolled by %s@%s" %
-                 (logged_in_user.get("username"), logged_in_user.get("realm")))
+        log.info("The token was enrolled by {0!s}@{1!s}".format(logged_in_user.get("username"), logged_in_user.get("realm")))
         return True

--- a/privacyidea/lib/policy.py
+++ b/privacyidea/lib/policy.py
@@ -476,7 +476,7 @@ class PolicyClass(object):
             rights = get_static_policy_definitions(scope).keys()
         # reduce the list
         rights = list(set(rights))
-        log.debug("returning the admin rights: %s" % rights)
+        log.debug("returning the admin rights: {0!s}".format(rights))
         return rights
 
     def ui_get_enroll_tokentypes(self, client, logged_in_user):
@@ -569,7 +569,7 @@ def set_policy(name=None, scope=None, action=None, realm=None, resolver=None,
         for k, v in action.items():
             if v is not True:
                 # value key
-                action_list.append("%s=%s" % (k, v))
+                action_list.append("{0!s}={1!s}".format(k, v))
             else:
                 # simple boolean value
                 action_list.append(k)
@@ -600,7 +600,7 @@ def enable_policy(name, enable=True):
     :return: ID of the policy
     """
     if not Policy.query.filter(Policy.name == name).first():
-        raise ParameterError("The policy with name '%s' does not exist" % name)
+        raise ParameterError("The policy with name '{0!s}' does not exist".format(name))
 
     # Update the policy
     p = set_policy(name=name, active=enable)
@@ -635,9 +635,9 @@ def export_policies(policies):
     file_contents = ""
     if policies:
         for policy in policies:
-            file_contents += "[%s]\n" % policy.get("name")
+            file_contents += "[{0!s}]\n".format(policy.get("name"))
             for key, value in policy.items():
-                file_contents += "%s = %s\n" % (key, value)
+                file_contents += "{0!s} = {1!s}\n".format(key, value)
             file_contents += "\n"
 
     return file_contents
@@ -670,7 +670,7 @@ def import_policies(file_contents):
                          time=policy.get("time", "")
                          )
         if ret > 0:
-            log.debug("import policy %s: %s" % (policy_name, ret))
+            log.debug("import policy {0!s}: {1!s}".format(policy_name, ret))
             res += 1
     return res
 

--- a/privacyidea/lib/policydecorators.py
+++ b/privacyidea/lib/policydecorators.py
@@ -115,7 +115,7 @@ def challenge_response_allowed(func):
                 realm=user_object.realm,
                 user=user_object.login,
                 client=clientip)
-            log.debug("Found these allowed tokentypes: %s" % allowed_tokentypes)
+            log.debug("Found these allowed tokentypes: {0!s}".format(allowed_tokentypes))
 
             # allowed_tokentypes is a list of actions from several policies. I
             # could look like this:
@@ -309,8 +309,8 @@ def auth_user_timelimit(wrapped_function, user_object, passw, options=None):
         # Check for maximum failed authentications
         # Always - also in case of unsuccessful authentication
         if len(max_fail) > 1:
-            raise PolicyError("Contradicting policies for %s" %
-                              ACTION.AUTHMAXFAIL)
+            raise PolicyError("Contradicting policies for {0!s}".format(
+                              ACTION.AUTHMAXFAIL))
         if len(max_fail) == 1:
             policy_count, tdelta = parse_timelimit(max_fail[0])
             fail_c = g.audit_object.get_count({"user": user_object.login,
@@ -331,8 +331,8 @@ def auth_user_timelimit(wrapped_function, user_object, passw, options=None):
             # Check for maximum successful authentications
             # Only in case of a successful authentication
             if len(max_success) > 1:
-                raise PolicyError("Contradicting policies for %s" %
-                                  ACTION.AUTHMAXSUCCESS)
+                raise PolicyError("Contradicting policies for {0!s}".format(
+                                  ACTION.AUTHMAXSUCCESS))
 
             if len(max_success) == 1:
                 policy_count, tdelta = parse_timelimit(max_success[0])
@@ -454,8 +454,8 @@ def login_mode(wrapped_function, *args, **kwds):
     kwds["options"] contains the flask g
     :return: calls the original function with the modified "check_otp" argument
     """
-    ERROR = "There are contradicting policies for the action %s!" % \
-            ACTION.LOGINMODE
+    ERROR = "There are contradicting policies for the action {0!s}!".format( \
+            ACTION.LOGINMODE)
     # if tokenclass.check_pin is called in any other way, options may be None
     #  or it might have no element "g".
     options = kwds.get("options") or {}
@@ -504,8 +504,8 @@ def auth_otppin(wrapped_function, *args, **kwds):
     :param **kwds: kwds["options"] contains the flask g
     :return: True or False
     """
-    ERROR = "There are contradicting policies for the action %s!" % \
-            ACTION.OTPPIN
+    ERROR = "There are contradicting policies for the action {0!s}!".format( \
+            ACTION.OTPPIN)
     # if tokenclass.check_pin is called in any other way, options may be None
     #  or it might have no element "g".
     options = kwds.get("options") or {}

--- a/privacyidea/lib/resolver.py
+++ b/privacyidea/lib/resolver.py
@@ -85,8 +85,7 @@ def save_resolver(params):
     # check the type
     resolvertypes = get_resolver_types()
     if resolvertype not in resolvertypes:
-            raise Exception("resolver type : %s not in %s" %
-                            (resolvertype, unicode(resolvertypes)))
+            raise Exception("resolver type : {0!s} not in {1!s}".format(resolvertype, unicode(resolvertypes)))
 
     # check the name
     resolvers = get_resolver_list(filter_resolver_name=resolvername)
@@ -134,8 +133,8 @@ def save_resolver(params):
         if t not in data:
             _missing = True
     if _missing:
-        raise Exception("type or description without necessary data! %s" %
-                        unicode(params))
+        raise Exception("type or description without necessary data! {0!s}".format(
+                        unicode(params)))
 
     # Everything passed. So lets actually create the resolver in the DB
     if update_resolver:
@@ -323,7 +322,7 @@ def get_resolver_object(resolvername):
     r_obj_class = get_resolver_class(r_type)
 
     if r_obj_class is None:
-        log.error("Can not find resolver with name %s " % resolvername)
+        log.error("Can not find resolver with name {0!s} ".format(resolvername))
     else:
         # create the resolver instance and load the config
         r_obj = r_obj_class()

--- a/privacyidea/lib/resolvers/LDAPIdResolver.py
+++ b/privacyidea/lib/resolvers/LDAPIdResolver.py
@@ -113,7 +113,7 @@ class IdResolver (UserIdResolver):
             # In fact we need the sAMAccountName. If the username mapping is
             # another attribute than the sAMAccountName the authentication
             # will fail!
-            bind_user = "%s\%s" % (domain_name, uinfo.get("username"))
+            bind_user = "{0!s}\{1!s}".format(domain_name, uinfo.get("username"))
         else:
             bind_user = self._getDN(uid)
 
@@ -121,8 +121,8 @@ class IdResolver (UserIdResolver):
         password = to_utf8(password)
 
         try:
-            log.debug("Authtype: %s" % self.authtype)
-            log.debug("user    : %s" % bind_user)
+            log.debug("Authtype: {0!s}".format(self.authtype))
+            log.debug("user    : {0!s}".format(bind_user))
             # Whatever happens. If we have an empty bind_user, we must break
             # since we must avoid anonymous binds!
             if not bind_user or len(bind_user) < 1:
@@ -134,15 +134,14 @@ class IdResolver (UserIdResolver):
                                        auto_referrals=not self.noreferrals)
             l.open()
             r = l.bind()
-            log.debug("bind result: %s" % r)
+            log.debug("bind result: {0!s}".format(r))
             if not r:
                 raise Exception("Wrong credentials")
             log.debug("bind seems successful.")
             l.unbind()
             log.debug("unbind successful.")
         except Exception as e:
-            log.warning("failed to check password for %r/%r: %r"
-                        % (uid, bind_user, e))
+            log.warning("failed to check password for {0!r}/{1!r}: {2!r}".format(uid, bind_user, e))
             return False
         
         return True
@@ -220,12 +219,11 @@ class IdResolver (UserIdResolver):
             dn = userId
         else:
             if self.uidtype == "objectGUID":
-                userId = uuid.UUID("{%s}" % userId).bytes_le
+                userId = uuid.UUID("{{{0!s}}}".format(userId)).bytes_le
                 userId = escape_bytes(userId)
             # get the DN for the Object
             self._bind()
-            filter = "(&%s(%s=%s))" % \
-                (self.searchfilter, self.uidtype, userId)
+            filter = "(&{0!s}({1!s}={2!s}))".format(self.searchfilter, self.uidtype, userId)
             self.l.search(search_base=self.basedn,
                           search_scope=self.scope,
                           search_filter=filter,
@@ -233,8 +231,7 @@ class IdResolver (UserIdResolver):
             r = self.l.response
             r = self._trim_result(r)
             if len(r) > 1:  # pragma: no cover
-                raise Exception("Found more than one object for uid %r"
-                                % userId)
+                raise Exception("Found more than one object for uid {0!r}".format(userId))
             if len(r) == 1:
                 dn = r[0].get("dn")
 
@@ -273,8 +270,7 @@ class IdResolver (UserIdResolver):
                           search_filter="(&" + self.searchfilter + ")",
                           attributes=self.userinfo.values())
         else:
-            filter = "(&%s(%s=%s))" %\
-                (self.searchfilter, self.uidtype, userId)
+            filter = "(&{0!s}({1!s}={2!s}))".format(self.searchfilter, self.uidtype, userId)
             self.l.search(search_base=self.basedn,
                               search_scope=self.scope,
                               search_filter=filter,
@@ -283,7 +279,7 @@ class IdResolver (UserIdResolver):
         r = self.l.response
         r = self._trim_result(r)
         if len(r) > 1:  # pragma: no cover
-            raise Exception("Found more than one object for uid %r" % userId)
+            raise Exception("Found more than one object for uid {0!r}".format(userId))
 
         for entry in r:
             attributes = entry.get("attributes")
@@ -335,8 +331,7 @@ class IdResolver (UserIdResolver):
         """
         userid = ""
         self._bind()
-        filter = "(&%s(%s=%s))" % \
-            (self.searchfilter, self.loginname_attribute,
+        filter = "(&{0!s}({1!s}={2!s}))".format(self.searchfilter, self.loginname_attribute,
              self._escape_loginname(LoginName))
 
         # create search attributes
@@ -352,8 +347,8 @@ class IdResolver (UserIdResolver):
         r = self.l.response
         r = self._trim_result(r)
         if len(r) > 1:  # pragma: no cover
-            raise Exception("Found more than one object for Loginname %r" %
-                            LoginName)
+            raise Exception("Found more than one object for Loginname {0!r}".format(
+                            LoginName))
         
         for entry in r:
             userid = self._get_uid(entry, self.uidtype)
@@ -380,13 +375,12 @@ class IdResolver (UserIdResolver):
                 comperator = ">="
                 if searchDict[search_key] in ["1", 1]:
                     comperator = "<="
-                filter += "(|(%s%s%s)(%s!=0))" % (self.userinfo[search_key],
+                filter += "(|({0!s}{1!s}{2!s})({3!s}!=0))".format(self.userinfo[search_key],
                                                   comperator,
                                                   get_ad_timestamp_now(),
                                                   self.userinfo[search_key])
             else:
-                filter += "(%s=%s)" % \
-                    (self.userinfo[search_key], searchDict[search_key])
+                filter += "({0!s}={1!s})".format(self.userinfo[search_key], searchDict[search_key])
         filter += ")"
 
         g = self.l.extend.standard.paged_search(search_base=self.basedn,
@@ -407,8 +401,8 @@ class IdResolver (UserIdResolver):
                 user['userid'] = self._get_uid(entry, self.uidtype)
                 ret.append(user)
             except Exception as exx:  # pragma: no cover
-                log.error("Error during fetching LDAP objects: %r" % exx)
-                log.debug("%s" % traceback.format_exc())
+                log.error("Error during fetching LDAP objects: {0!r}".format(exx))
+                log.debug("{0!s}".format(traceback.format_exc()))
 
         return ret
     
@@ -535,7 +529,7 @@ class IdResolver (UserIdResolver):
                                   use_ssl=ssl,
                                   connect_timeout=float(timeout))
             server_pool.add(server)
-            log.debug("Added %s, %s, %s to server pool." % (host, port, ssl))
+            log.debug("Added {0!s}, {1!s}, {2!s} to server pool.".format(host, port, ssl))
         return server_pool
 
     @classmethod
@@ -634,7 +628,7 @@ class IdResolver (UserIdResolver):
             success = True
             
         except Exception as e:
-            desc = "%r" % e
+            desc = "{0!r}".format(e)
         
         return success, desc
 
@@ -684,6 +678,6 @@ class IdResolver (UserIdResolver):
                                  check_names=check_names,
                                  auto_referrals=auto_referrals)
         else:
-            raise Exception("Authtype %s not supported" % authtype)
+            raise Exception("Authtype {0!s} not supported".format(authtype))
 
         return l

--- a/privacyidea/lib/resolvers/PasswdIdResolver.py
+++ b/privacyidea/lib/resolvers/PasswdIdResolver.py
@@ -126,7 +126,7 @@ class IdResolver (UserIdResolver):
         if self.fileName == "":
             self.fileName = "/etc/passwd"
 
-        log.info('loading users from file %s from within %r' % (self.fileName,
+        log.info('loading users from file {0!s} from within {1!r}'.format(self.fileName,
                                                                 os.getcwd()))
         with open(self.fileName, "r") as fileHandle:
             ID = self.sF["userid"]
@@ -141,10 +141,10 @@ class IdResolver (UserIdResolver):
                     continue
 
                 fields = line.split(":", 7)
-                self.nameDict["%s" % fields[NAME]] = fields[ID]
+                self.nameDict["{0!s}".format(fields[NAME])] = fields[ID]
 
                 # for speed reason - build a revers lookup
-                self.reversDict[fields[ID]] = "%s" % fields[NAME]
+                self.reversDict[fields[ID]] = "{0!s}".format(fields[NAME])
 
                 # for full info store the line
                 self.descDict[fields[ID]] = fields
@@ -190,22 +190,21 @@ class IdResolver (UserIdResolver):
         :return: True or False
         :rtype: bool
         """
-        log.info("checking password for user uid %s" % uid)
+        log.info("checking password for user uid {0!s}".format(uid))
         cryptedpasswd = self.passDict[uid]
-        log.debug("We found the crypted pass %s for uid %s"
-                  % (cryptedpasswd, uid))
+        log.debug("We found the crypted pass {0!s} for uid {1!s}".format(cryptedpasswd, uid))
         if cryptedpasswd:
             if cryptedpasswd == 'x' or cryptedpasswd == '*':
                 err = "Sorry, currently no support for shadow passwords"
-                log.error("%s" % err)
+                log.error("{0!s}".format(err))
                 raise NotImplementedError(err)
             cp = crypt.crypt(password, cryptedpasswd)
-            log.debug("crypted pass is %s" % cp)
+            log.debug("crypted pass is {0!s}".format(cp))
             if crypt.crypt(password, cryptedpasswd) == cryptedpasswd:
-                log.info("successfully authenticated user uid %s" % uid)
+                log.info("successfully authenticated user uid {0!s}".format(uid))
                 return True
             else:
-                log.warning("user uid %s failed to authenticate" % uid)
+                log.warning("user uid {0!s} failed to authenticate".format(uid))
                 return False
         else:
             log.warning("Failed to verify password. No crypted password "

--- a/privacyidea/lib/resolvers/SCIMIdResolver.py
+++ b/privacyidea/lib/resolvers/SCIMIdResolver.py
@@ -239,12 +239,12 @@ class IdResolver (UserIdResolver):
             content = cls._search_users(param.get("Resourceserver"),
                                                     access_token, "")
             num = content.get("totalResults", -1)
-            desc = "Found %s users" % num
+            desc = "Found {0!s} users".format(num)
             success = True
         except Exception as exx:
-            log.error("Failed to retrieve users: %s" % exx)
-            log.debug("%s" % traceback.format_exc(exx))
-            desc = "failed to retrieve users: %s" % exx
+            log.error("Failed to retrieve users: {0!s}".format(exx))
+            log.debug("{0!s}".format(traceback.format_exc(exx)))
+            desc = "failed to retrieve users: {0!s}".format(exx)
             
         return success, desc
 
@@ -260,7 +260,7 @@ class IdResolver (UserIdResolver):
         url = '{0}/Users?{1}'.format(resource_server, urlencode(params))
         resp = requests.get(url, headers=headers)
         if resp.status_code != 200:
-            info = "Could not get user list: %s" % resp.status_code
+            info = "Could not get user list: {0!s}".format(resp.status_code)
             log.error(info)
             raise Exception(info)
         j_content = yaml.load(resp.content)
@@ -286,7 +286,7 @@ class IdResolver (UserIdResolver):
         resp = requests.get(url, headers=headers)
 
         if resp.status_code != 200:
-            info = "Could not get user: %s" % resp.status_code
+            info = "Could not get user: {0!s}".format(resp.status_code)
             log.error(info)
             raise Exception(info)
         j_content = yaml.load(resp.content)
@@ -298,12 +298,12 @@ class IdResolver (UserIdResolver):
 
         auth = base64.encodestring(client + ':' + secret)
 
-        url = "%s/oauth/token?grant_type=client_credentials" % server
+        url = "{0!s}/oauth/token?grant_type=client_credentials".format(server)
         resp = requests.get(url,
                             headers={'Authorization': 'Basic ' + auth})
 
         if resp.status_code != 200:
-            info = "Could not get access token: %s" % resp.status_code
+            info = "Could not get access token: {0!s}".format(resp.status_code)
             log.error(info)
             raise Exception(info)
 

--- a/privacyidea/lib/resolvers/SQLIdResolver.py
+++ b/privacyidea/lib/resolvers/SQLIdResolver.py
@@ -87,14 +87,14 @@ class PasswordHash(object):
         self.iteration_count_log2 = iteration_count_log2
         self.portable_hashes = portable_hashes
         self.algorithm = algorithm
-        self.random_state = '%r%r' % (time.time(), _pid)
+        self.random_state = '{0!r}{1!r}'.format(time.time(), _pid)
 
     def get_random_bytes(self, count):
         outp = ''
         try:
             outp = os.urandom(count)
         except Exception as exx:  # pragma: no cover
-            log.debug("problem getting os.urandom: %s" % exx)
+            log.debug("problem getting os.urandom: {0!s}".format(exx))
         if len(outp) < count:  # pragma: no cover
             outp = ''
             rem = count
@@ -394,11 +394,10 @@ class IdResolver (UserIdResolver):
                                                       
             for r in result:
                 if userinfo.keys():  # pragma: no cover
-                    raise Exception("More than one user with userid %s found!"
-                                    % userId)
+                    raise Exception("More than one user with userid {0!s} found!".format(userId))
                 userinfo = self._get_user_from_mapped_object(r)
         except Exception as exx:  # pragma: no cover
-            log.error("Could not get the userinformation: %r" % exx)
+            log.error("Could not get the userinformation: {0!r}".format(exx))
         
         return userinfo
     
@@ -439,7 +438,7 @@ class IdResolver (UserIdResolver):
                 user = self._get_user_from_mapped_object(r)
                 userid = user["id"]
         except Exception as exx:    # pragma: no cover
-            log.error("Could not get the userinformation: %r" % exx)
+            log.error("Could not get the userinformation: {0!r}".format(exx))
         
         return userid
     
@@ -456,8 +455,8 @@ class IdResolver (UserIdResolver):
             if self.map.get("userid") in r:
                 user["id"] = r[self.map.get("userid")]
         except UnicodeEncodeError:  # pragma: no cover
-            log.error("Failed to convert user: %r" % r)
-            log.debug("%s" % traceback.format_exc())
+            log.error("Failed to convert user: {0!r}".format(r))
+            log.debug("{0!s}".format(traceback.format_exc()))
         
         for key in ["username",
                     "surname",
@@ -478,8 +477,8 @@ class IdResolver (UserIdResolver):
 
             except UnicodeDecodeError:  # pragma: no cover
                 user[key] = "decoding_error"
-                log.error("Failed to convert user: %r" % r)
-                log.debug("%s" % traceback.format_exc())
+                log.error("Failed to convert user: {0!r}".format(r))
+                log.debug("{0!s}".format(traceback.format_exc()))
         
         return user
 
@@ -564,9 +563,9 @@ class IdResolver (UserIdResolver):
                   'Server': self.server,
                   'Database': self.database}
         self.connect_string = self._create_connect_string(params)
-        log.info("using the connect string %s" % self.connect_string)
+        log.info("using the connect string {0!s}".format(self.connect_string))
         try:
-            log.debug("using pool_size=%s and pool_timeout=%s" % (
+            log.debug("using pool_size={0!s} and pool_timeout={1!s}".format(
                       self.pool_size, self.pool_timeout))
             self.engine = create_engine(self.connect_string,
                                         encoding=self.encoding,
@@ -626,12 +625,12 @@ class IdResolver (UserIdResolver):
         password = ""
         conParams = ""
         if param.get("Port"):
-            port = ":%s" % param.get("Port")
+            port = ":{0!s}".format(param.get("Port"))
         if param.get("Password"):
-            password = ":%s" % param.get("Password")
+            password = ":{0!s}".format(param.get("Password"))
         if param.get("conParams"):
-            conParams = "?%s" % param.get("conParams")
-        connect_string = "%s://%s%s%s%s%s/%s%s" % (param.get("Driver", ""),
+            conParams = "?{0!s}".format(param.get("conParams"))
+        connect_string = "{0!s}://{1!s}{2!s}{3!s}{4!s}{5!s}/{6!s}{7!s}".format(param.get("Driver", ""),
                                                    param.get("User", ""),
                                                    password,
                                                    "@" if (param.get("User")
@@ -644,7 +643,7 @@ class IdResolver (UserIdResolver):
         # SQLAlchemy does not like a unicode connect string!
         if param.get("Driver").lower() == "sqlite":
             connect_string = str(connect_string)
-        log.debug("SQL connectstring: %r" % connect_string)
+        log.debug("SQL connectstring: {0!r}".format(connect_string))
         return connect_string
             
     @classmethod
@@ -668,7 +667,7 @@ class IdResolver (UserIdResolver):
         desc = None
         
         connect_string = cls._create_connect_string(param)
-        log.info("using the connect string %s" % connect_string)
+        log.info("using the connect string {0!s}".format(connect_string))
         engine = create_engine(connect_string)
         # create a configured "Session" class
         session = sessionmaker(bind=engine)()
@@ -681,9 +680,9 @@ class IdResolver (UserIdResolver):
             result = session.query(TABLE).filter(filter_condition).count()
 
             num = result
-            desc = "Found %i users." % num
+            desc = "Found {0:d} users.".format(num)
         except Exception as exx:
-            desc = "failed to retrieve users: %s" % exx
+            desc = "failed to retrieve users: {0!s}".format(exx)
             
         return num, desc
 
@@ -701,7 +700,7 @@ class IdResolver (UserIdResolver):
         """
         attributes = attributes or {}
         kwargs = self._attributes_to_db_columns(attributes)
-        log.debug("Insert new user with attributes %s" % kwargs)
+        log.debug("Insert new user with attributes {0!s}".format(kwargs))
         r = self.TABLE.insert(**kwargs)
         self.db.commit()
         # Return the UID of the new object
@@ -752,7 +751,7 @@ class IdResolver (UserIdResolver):
             self.session.delete(user_obj)
             self.session.commit()
         except Exception as exx:
-            log.error("Error deleting user: %s" % exx)
+            log.error("Error deleting user: {0!s}".format(exx))
             res = False
         return res
 

--- a/privacyidea/lib/security/default.py
+++ b/privacyidea/lib/security/default.py
@@ -84,59 +84,51 @@ class SecurityModule(object):
         fname = 'setup_module'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
     ''' base methods '''
     def random(self, length):
         fname = 'random'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
     def encrypt(self, value, iv=None):
         fname = 'encrypt'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
     def decrypt(self, value, iv=None):
         fname = 'decrypt'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
     ''' higer level methods '''
     def encrypt_password(self, clear_pass):
         fname = 'encrypt_password'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
     def encrypt_pin(self, clear_pin):
         fname = 'encrypt_pin'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
     def decrypt_password(self, crypt_pass):
         fname = 'decrypt_password'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
     def decrypt_pin(self, crypt_pin):
         fname = 'decrypt_pin'
         log.error("This is the base class. You should implement "
                   "the method : %s " % (fname,))
-        raise NotImplementedError("Should have been implemented %s"
-                                  % fname)
+        raise NotImplementedError("Should have been implemented {0!s}".format(fname))
 
 
 class DefaultSecurityModule(SecurityModule):
@@ -345,7 +337,7 @@ class DefaultSecurityModule(SecurityModule):
         cipher = aes.encrypt(input_data)
         iv_hex = binascii.hexlify(iv)
         cipher_hex = binascii.hexlify(cipher)
-        return "%s:%s" % (iv_hex, cipher_hex)
+        return "{0!s}:{1!s}".format(iv_hex, cipher_hex)
 
     @staticmethod
     def password_decrypt(data, password):

--- a/privacyidea/lib/smsprovider/HttpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/HttpSMSProvider.py
@@ -59,7 +59,7 @@ class HttpSMSProvider(ISMSProvider):
             log.warning("can not submit message. URL is missing.")
             raise SMSError(-1, "No URL specified in the provider config.")
 
-        log.debug("submitting message %s to %s" % (message, phone))
+        log.debug("submitting message {0!s} to {1!s}".format(message, phone))
 
         method = self.config.get('HTTP_Method', 'GET')
         username = self.config.get('USERNAME', None)
@@ -102,8 +102,8 @@ class HttpSMSProvider(ISMSProvider):
                       verify=ssl_verify,
                       auth=basic_auth,
                       proxies=proxies)
-        log.debug("queued SMS on the HTTP gateway. status code returned: %s" %
-                  r.status_code)
+        log.debug("queued SMS on the HTTP gateway. status code returned: {0!s}".format(
+                  r.status_code))
 
         # We assume, that all gateway return with HTTP Status Code 200
         if r.status_code != 200:
@@ -123,7 +123,7 @@ class HttpSMSProvider(ISMSProvider):
         urldata[messageKey] = message
         params = self.config.get('PARAMETER', {})
         urldata.update(params)
-        log.debug("[getParameters] urldata: %s" % urldata)
+        log.debug("[getParameters] urldata: {0!s}".format(urldata))
         return urldata
 
     def _check_success(self, response):

--- a/privacyidea/lib/smsprovider/SMSProvider.py
+++ b/privacyidea/lib/smsprovider/SMSProvider.py
@@ -36,13 +36,13 @@ class SMSError(Exception):
         self.description = description
 
     def __repr__(self):
-        ret = '%s(error_id=%r, description=%r)' % (type(self).__name__,
+        ret = '{0!s}(error_id={1!r}, description={2!r})'.format(type(self).__name__,
                                                    self.error_id,
                                                    self.description)
         return ret
 
     def __str__(self):
-        ret = '%s' % self.description
+        ret = '{0!s}'.format(self.description)
         return ret
 
 

--- a/privacyidea/lib/smsprovider/SipgateSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SipgateSMSProvider.py
@@ -79,8 +79,8 @@ class SipgateSMSProvider(ISMSProvider):
                           auth=(username, password),
                           proxies=proxies)
 
-        log.debug("SMS submitted: %s" % r.status_code)
-        log.debug("response content: %s" % r.text)
+        log.debug("SMS submitted: {0!s}".format(r.status_code))
+        log.debug("response content: {0!s}".format(r.text))
 
         if r.status_code != 200:
             raise SMSError(r.status_code, "SMS could not be "

--- a/privacyidea/lib/smsprovider/SmtpSMSProvider.py
+++ b/privacyidea/lib/smsprovider/SmtpSMSProvider.py
@@ -64,7 +64,7 @@ class SmtpSMSProvider(ISMSProvider):
                       "MAILSERVER and MAILSENDER) needed" % self.config)
             raise SMSError(-1, "Incomplete SMS config.")
 
-        log.debug("submitting message %s to %s" % (body, phone))
+        log.debug("submitting message {0!s} to {1!s}".format(body, phone))
         recipient = string.replace(recipient, PHONE_TAG, phone)
         subject = string.replace(subject, PHONE_TAG, phone)
         subject = string.replace(subject, MSG_TAG, message)

--- a/privacyidea/lib/smtpserver.py
+++ b/privacyidea/lib/smtpserver.py
@@ -87,17 +87,17 @@ class SMTPServer(object):
         mail.ehlo()
         # Start TLS if required
         if config.tls:
-            log.debug("Trying to STARTTLS: %s" % config.tls)
+            log.debug("Trying to STARTTLS: {0!s}".format(config.tls))
             mail.starttls()
         # Authenticate, if a username is given.
         if config.username:
-            log.debug("Doing authentication with %s" % config.username)
+            log.debug("Doing authentication with {0!s}".format(config.username))
             password = decryptPassword(config.password)
             if password == FAILED_TO_DECRYPT_PASSWORD:
                 password = config.password
             mail.login(config.username, password)
         r = mail.sendmail(mail_from, recipient, msg.as_string())
-        log.info("Mail sent: %s" % r)
+        log.info("Mail sent: {0!s}".format(r))
         # r is a dictionary like {"recp@destination.com": (200, 'OK')}
         # we change this to True or False
         success = True
@@ -105,7 +105,7 @@ class SMTPServer(object):
             res_id, res_text = r.get(one_recipient, (200, "OK"))
             if res_id != 200 and res_text != "OK":
                 success = False
-                log.error("Failed to send email to %s: %s, %s" % (one_recipient,
+                log.error("Failed to send email to {0!s}: {1!s}, {2!s}".format(one_recipient,
                                                                   res_id,
                                                                   res_text))
         mail.quit()

--- a/privacyidea/lib/stats.py
+++ b/privacyidea/lib/stats.py
@@ -60,15 +60,15 @@ def get_statistics(auditobject, start_time=datetime.datetime.now()
 
     # authentication successful/fail per user or serial
     for key in ["user", "serial"]:
-        result["validate_%s_plot" % key] = _get_success_fail(df, key)
+        result["validate_{0!s}_plot".format(key)] = _get_success_fail(df, key)
 
     # get simple usage
     for key in ["serial", "action"]:
-        result["%s_plot" % key] = _get_number_of(df, key)
+        result["{0!s}_plot".format(key)] = _get_number_of(df, key)
 
     # failed authentication requests
     for key in ["user", "serial"]:
-        result["validate_failed_%s_plot" % key] = _get_fail(df, key)
+        result["validate_failed_{0!s}_plot".format(key)] = _get_fail(df, key)
 
     result["admin_plot"] = _get_number_of(df, "action", nums=20)
 
@@ -90,10 +90,10 @@ def _get_success_fail(df, key):
         o_data = output.getvalue()
         output.close()
         image_data = o_data.encode("base64")
-        image_uri = 'data:image/png;base64,%s' % image_data
+        image_uri = 'data:image/png;base64,{0!s}'.format(image_data)
     except Exception as exx:
         log.info(exx)
-        image_uri = "%s" % exx
+        image_uri = "{0!s}".format(exx)
     return image_uri
 
 def _get_fail(df, key):
@@ -118,10 +118,10 @@ def _get_fail(df, key):
         o_data = output.getvalue()
         output.close()
         image_data = o_data.encode("base64")
-        image_uri = 'data:image/png;base64,%s' % image_data
+        image_uri = 'data:image/png;base64,{0!s}'.format(image_data)
     except Exception as exx:
         log.info(exx)
-        image_uri = "%s" % exx
+        image_uri = "{0!s}".format(exx)
     return image_uri
 
 
@@ -147,13 +147,13 @@ def _get_number_of(df, key, nums=5):
         fig = series.plot(ax=ax, kind="bar", colormap="Blues",
                           legend=False,
                           stacked=False,
-                          title="Numbers of %s" % key,
+                          title="Numbers of {0!s}".format(key),
                           grid=True).get_figure()
         fig.savefig(output, format="png")
         o_data = output.getvalue()
         output.close()
         image_data = o_data.encode("base64")
-        image_uri = 'data:image/png;base64,%s' % image_data
+        image_uri = 'data:image/png;base64,{0!s}'.format(image_data)
     except Exception as exx:
         log.info(exx)
         image_uri = "No data"

--- a/privacyidea/lib/token.py
+++ b/privacyidea/lib/token.py
@@ -108,10 +108,10 @@ def create_tokenclass_object(db_token):
         try:
             token_object = token_class(db_token)
         except Exception as e:  # pragma: no cover
-            raise TokenAdminError("create_tokenclass_object failed:  %r" % e,
+            raise TokenAdminError("create_tokenclass_object failed:  {0!r}".format(e),
                                   id=1609)
     else:
-        log.error('type %r not found in tokenclasses' % tokentype)
+        log.error('type {0!r} not found in tokenclasses'.format(tokentype))
 
     return token_object
 
@@ -159,7 +159,7 @@ def _create_token_query(tokentype=None, realm=None, assigned=None, user=None,
         elif assigned is True:
             sql_query = sql_query.filter(Token.user_id != "")
         else:
-            log.warning("assigned value not in [True, False] %r" % assigned)
+            log.warning("assigned value not in [True, False] {0!r}".format(assigned))
 
     if realm is not None:
         # filter for the realm
@@ -399,7 +399,7 @@ def get_tokens_paginate(tokentype=None, realm=None, assigned=None, user=None,
                     token_dict["username"] = userobject.login
                     token_dict["user_realm"] = userobject.realm
             except Exception as exx:
-                log.error("User information can not be retrieved: %s" % exx)
+                log.error("User information can not be retrieved: {0!s}".format(exx))
                 token_dict["username"] = "**resolver error**"
 
             token_list.append(token_dict)
@@ -454,7 +454,7 @@ def check_serial(serial):
         # as long as we find a token, modify the serial:
         i += 1
         result = False
-        new_serial = "%s_%02i" % (serial, i)
+        new_serial = "{0!s}_{1:02d}".format(serial, i)
 
     return result, new_serial
 
@@ -639,7 +639,7 @@ def get_otp(serial, current_time=None):
     tokenobject_list = get_tokens(serial=serial)
 
     if not tokenobject_list:
-        log.warning("there is no token with serial %r" % serial)
+        log.warning("there is no token with serial {0!r}".format(serial))
         return -1, "", "", ""
 
     tokenobject = tokenobject_list[0]
@@ -673,13 +673,12 @@ def get_multi_otp(serial, count=0, epoch_start=0, epoch_end=0,
     ret = {"result": False}
     tokenobject_list = get_tokens(serial=serial)
     if not tokenobject_list:
-        log.warning("there is no token with serial %r" % serial)
-        ret["error"] = "No token with serial %s found." % serial
+        log.warning("there is no token with serial {0!r}".format(serial))
+        ret["error"] = "No token with serial {0!s} found.".format(serial)
 
     else:
         tokenobject = tokenobject_list[0]
-        log.debug("getting multiple otp values for token %r. curTime=%r" %
-                  (tokenobject, curTime))
+        log.debug("getting multiple otp values for token {0!r}. curTime={1!r}".format(tokenobject, curTime))
 
         res, error, otp_dict = tokenobject.\
             get_multi_otp(count=count,
@@ -687,7 +686,7 @@ def get_multi_otp(serial, count=0, epoch_start=0, epoch_end=0,
                           epoch_end=epoch_end,
                           curTime=curTime,
                           timestamp=timestamp)
-        log.debug("received %r, %r, and %r otp values" % (res, error,
+        log.debug("received {0!r}, {1!r}, and {2!r} otp values".format(res, error,
                                                           len(otp_dict)))
 
         if res is True:
@@ -721,9 +720,9 @@ def get_token_by_otp(token_list, otp="", window=10):
     result_list = []
 
     for token in token_list:
-        log.debug("checking token %r" % token.get_serial())
+        log.debug("checking token {0!r}".format(token.get_serial()))
         r = token.check_otp_exist(otp=otp, window=window)
-        log.debug("result = %d" % int(r))
+        log.debug("result = {0:d}".format(int(r)))
         if r >= 0:
             result_list.append(token)
 
@@ -778,7 +777,7 @@ def get_tokenserial_of_transaction(transaction_id):
     if challenge:
         serial = challenge.serial
     else:
-        log.info('no challenge found for transaction_id %r' % transaction_id)
+        log.info('no challenge found for transaction_id {0!r}'.format(transaction_id))
 
     return serial
 
@@ -795,11 +794,11 @@ def gen_serial(tokentype=None, prefix=None):
     """
     def _gen_serial(_prefix, _tokennum):
         h_serial = ''
-        num_str = '%.4d' % _tokennum
+        num_str = '{0:.4d}'.format(_tokennum)
         h_len = 8 - len(num_str)
         if h_len > 0:
             h_serial = binascii.hexlify(os.urandom(h_len)).upper()[0:h_len]
-        return "%s%s%s" % (_prefix, num_str, h_serial)
+        return "{0!s}{1!s}{2!s}".format(_prefix, num_str, h_serial)
 
     if not tokentype:
         tokentype = 'PIUN'
@@ -851,10 +850,8 @@ def init_token(param, user=None, tokenrealms=None):
     # unsupported tokentype
     tokentypes = get_token_types()
     if tokentype.lower() not in tokentypes:
-        log.error('type %r not found in tokentypes: %r' %
-                  (tokentype, tokentypes))
-        raise TokenAdminError("init token failed: unknown token type %r"
-                               % tokentype, id=1610)
+        log.error('type {0!r} not found in tokentypes: {1!r}'.format(tokentype, tokentypes))
+        raise TokenAdminError("init token failed: unknown token type {0!r}".format(tokentype), id=1610)
 
     # Check, if a token with this serial already exist
     # create a list of the found tokens
@@ -875,7 +872,7 @@ def init_token(param, user=None, tokenrealms=None):
                                                                   old_typ,
                                                                   tokentype))
             log.error(msg)
-            raise TokenAdminError("initToken failed: %s" % msg)
+            raise TokenAdminError("initToken failed: {0!s}".format(msg))
 
     # if there is a realm as parameter (and the realm is not empty), but no
     # user, we assign the token to this realm.
@@ -914,8 +911,8 @@ def init_token(param, user=None, tokenrealms=None):
 
     except Exception as e:  # pragma: no cover
         log.error('token create failed!')
-        log.debug("%s" % traceback.format_exc())
-        raise TokenAdminError("token create failed %r" % e, id=1112)
+        log.debug("{0!s}".format(traceback.format_exc()))
+        raise TokenAdminError("token create failed {0!r}".format(e), id=1112)
 
     # Set the validity period
     validity_period_start = param.get("validity_period_start")
@@ -1044,7 +1041,7 @@ def assign_token(serial, user, pin=None, encrypt_pin=False):
     tokenobject_list = get_tokens(serial=serial)
 
     if not tokenobject_list:
-        log.warning("no tokens found with serial: %r" % serial)
+        log.warning("no tokens found with serial: {0!r}".format(serial))
         raise TokenAdminError("no token found!", id=1102)
 
     tokenobject = tokenobject_list[0]
@@ -1052,9 +1049,9 @@ def assign_token(serial, user, pin=None, encrypt_pin=False):
     # Check if the token already belongs to another user
     old_user = tokenobject.user
     if old_user:
-        log.warning("token already assigned to user: %r" % old_user)
-        raise TokenAdminError("Token already assigned to user %r" %
-                              old_user, id=1103)
+        log.warning("token already assigned to user: {0!r}".format(old_user))
+        raise TokenAdminError("Token already assigned to user {0!r}".format(
+                              old_user), id=1103)
 
     tokenobject.set_user(user)
     if pin is not None:
@@ -1067,8 +1064,7 @@ def assign_token(serial, user, pin=None, encrypt_pin=False):
         tokenobject.save()
     except Exception as e:  # pragma: no cover
         log.error('update Token DB failed')
-        raise TokenAdminError("Token assign failed for %r/%s : %r"
-                              % (user, serial, e), id=1105)
+        raise TokenAdminError("Token assign failed for {0!r}/{1!s} : {2!r}".format(user, serial, e), id=1105)
 
     log.debug("successfully assigned token with serial "
               "%r to user %r" % (serial, user))
@@ -1087,7 +1083,7 @@ def unassign_token(serial, user=None):
     tokenobject_list = get_tokens(serial=serial, user=user)
 
     if not tokenobject_list:
-        log.warning("no tokens found with serial: %r" % serial)
+        log.warning("no tokens found with serial: {0!r}".format(serial))
         raise TokenAdminError("no token found!", id=1102)
 
     tokenobject = tokenobject_list[0]
@@ -1101,10 +1097,9 @@ def unassign_token(serial, user=None):
         tokenobject.save()
     except Exception as e:  # pragma: no cover
         log.error('update token DB failed')
-        raise TokenAdminError("Token unassign failed for %r: %r"
-                              % (serial, e), id=1105)
+        raise TokenAdminError("Token unassign failed for {0!r}: {1!r}".format(serial, e), id=1105)
 
-    log.debug("successfully unassigned token with serial %r" % serial)
+    log.debug("successfully unassigned token with serial {0!r}".format(serial))
     return True
 
 
@@ -1173,9 +1168,9 @@ def set_pin(serial, pin, user=None, encrypt_pin=False):
     if isinstance(user, basestring):
         # check if by accident the wrong parameter (like PIN)
         # is put into the user attribute
-        log.warning("Parameter user must not be a string: %r" % user)
-        raise ParameterError("Parameter user must not be a string: %r" %
-                             user, id=1212)
+        log.warning("Parameter user must not be a string: {0!r}".format(user))
+        raise ParameterError("Parameter user must not be a string: {0!r}".format(
+                             user), id=1212)
 
     tokenobject_list = get_tokens(serial=serial, user=user)
 
@@ -1657,17 +1652,17 @@ def lost_token(serial, new_serial=None, password=None,
     :return: result dictionary
     """
     res = {}
-    new_serial = new_serial or "lost%s" % serial
+    new_serial = new_serial or "lost{0!s}".format(serial)
     user = get_token_owner(serial)
 
-    log.debug("doing lost token for serial %r and user %r" % (serial, user))
+    log.debug("doing lost token for serial {0!r} and user {1!r}".format(serial, user))
 
     if user is None or user.is_empty():
         err = "You can only define a lost token for an assigned token."
-        log.warning("%s" % err)
+        log.warning("{0!s}".format(err))
         raise TokenAdminError(err, id=2012)
 
-    character_pool = "%s%s%s" % (string.ascii_lowercase,
+    character_pool = "{0!s}{1!s}{2!s}".format(string.ascii_lowercase,
                                  string.ascii_uppercase, string.digits)
     if contents != "":
         character_pool = ""
@@ -1687,8 +1682,8 @@ def lost_token(serial, new_serial=None, password=None,
 
     tokenobject = init_token({"otpkey": password, "serial": new_serial,
                               "type": "pw",
-                              "description": "temporary replacement for %s" %
-                                             serial})
+                              "description": "temporary replacement for {0!s}".format(
+                                             serial)})
 
     res['init'] = tokenobject is not None
     if res['init']:
@@ -1699,7 +1694,7 @@ def lost_token(serial, new_serial=None, password=None,
         end_date = (datetime.date.today()
                     + datetime.timedelta(days=validity)).strftime("%d/%m/%y")
 
-        end_date = "%s 23:59" % end_date
+        end_date = "{0!s} 23:59".format(end_date)
         tokenobject_list = get_tokens(serial=new_serial)
         for tokenobject in tokenobject_list:
             tokenobject.set_validity_period_end(end_date)
@@ -1858,7 +1853,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None):
                  'token_type': tokenobject.get_type(),
                  'weight': 0}
 
-        log.debug("Found user with loginId %r: %r" % (
+        log.debug("Found user with loginId {0!r}: {1!r}".format(
                   tokenobject.user, tokenobject.get_serial()))
 
         if tokenobject.is_challenge_response(passw, user=user, options=options):
@@ -1921,7 +1916,7 @@ def check_token_list(tokenobject_list, passw, user=None, options=None):
     if valid_token_list:
         # One ore more successfully authenticating tokens found
         # We need to return success
-        message_list = ["matching %i tokens" % len(valid_token_list)]
+        message_list = ["matching {0:d} tokens".format(len(valid_token_list))]
         # write serial numbers or something to audit log
         for token_obj in valid_token_list:
             token_obj.inc_count_auth()
@@ -2032,14 +2027,14 @@ def get_dynamic_policy_definitions(scope=None):
            SCOPE.ENROLL: {},
            SCOPE.AUTHZ: {}}
     for ttype in get_token_types():
-        pol[SCOPE.ADMIN]["enroll%s" % ttype.upper()] \
+        pol[SCOPE.ADMIN]["enroll{0!s}".format(ttype.upper())] \
             = {'type': 'bool',
                'desc': _('Admin is allowed to initalize %s tokens.') %
                        ttype.upper()}
 
         conf = get_tokenclass_info(ttype, section='user')
         if 'enroll' in conf:
-            pol[SCOPE.USER]["enroll%s" % ttype.upper()] = {
+            pol[SCOPE.USER]["enroll{0!s}".format(ttype.upper())] = {
                 'type': 'bool',
                 'desc': _("The user is allowed to enroll a %s token.") % ttype}
 
@@ -2059,7 +2054,7 @@ def get_dynamic_policy_definitions(scope=None):
                 for pol_def in pol_entry:
                     set_def = pol_def
                     if pol_def.startswith(ttype) is not True:
-                        set_def = '%s_%s' % (ttype, pol_def)
+                        set_def = '{0!s}_{1!s}'.format(ttype, pol_def)
 
                     pol[pol_section][set_def] = pol_entry.get(pol_def)
 

--- a/privacyidea/lib/tokenclass.py
+++ b/privacyidea/lib/tokenclass.py
@@ -180,8 +180,8 @@ class TokenClass(object):
         """
         user_object = self.user
         user_info = user_object.info
-        user_identifier = "%s_%s" % (user_object.login, user_object.realm)
-        user_displayname = "%s %s" % (user_info.get("givenname", "."),
+        user_identifier = "{0!s}_{1!s}".format(user_object.login, user_object.realm)
+        user_displayname = "{0!s} {1!s}".format(user_info.get("givenname", "."),
                                       user_info.get("surname", "."))
         return user_identifier, user_displayname
 
@@ -1076,10 +1076,10 @@ class TokenClass(object):
         """
         ldict = {}
         for attr in self.__dict__:
-            key = "%r" % attr
-            val = "%r" % getattr(self, attr)
+            key = "{0!r}".format(attr)
+            val = "{0!r}".format(getattr(self, attr))
             ldict[key] = val
-        res = "<%r %r>" % (self.__class__, ldict)
+        res = "<{0!r} {1!r}>".format(self.__class__, ldict)
         return res
 
     def get_init_detail(self, params=None, user=None):
@@ -1111,7 +1111,7 @@ class TokenClass(object):
 
         if otpkey is not None:
             response_detail["otpkey"] = {"description": "OTP seed",
-                                         "value": "seed://%s" % otpkey,
+                                         "value": "seed://{0!s}".format(otpkey),
                                          "img": create_img(otpkey, width=200)}
 
         return response_detail
@@ -1340,8 +1340,8 @@ class TokenClass(object):
         :param g: The Flask global object g
         :return: Flask Response or text
         """
-        raise ParameterError("%s does not support the API endpoint" %
-                             cls.get_tokentype())
+        raise ParameterError("{0!s} does not support the API endpoint".format(
+                             cls.get_tokentype()))
         return "json", {}
         # or return "text", "OK"
 

--- a/privacyidea/lib/tokens/HMAC.py
+++ b/privacyidea/lib/tokens/HMAC.py
@@ -142,11 +142,10 @@ class HmacOtp(object):
             start = 0 if (start < 0) else start
             end = self.counter + (window)
 
-        log.debug("OTP range counter: %r - %r" % (start, end))
+        log.debug("OTP range counter: {0!r} - {1!r}".format(start, end))
         for c in range(start, end):
             otpval = self.generate(c)
-            log.debug("calculating counter %r: %r %r"
-                      % (c, anOtpVal, otpval))
+            log.debug("calculating counter {0!r}: {1!r} {2!r}".format(c, anOtpVal, otpval))
 
             if unicode(otpval) == unicode(anOtpVal):
                 res = c

--- a/privacyidea/lib/tokens/emailtoken.py
+++ b/privacyidea/lib/tokens/emailtoken.py
@@ -225,7 +225,7 @@ class EmailTokenClass(HotpTokenClass):
 
         if self.is_active() is True:
             counter = self.get_otp_count()
-            log.debug("counter=%r" % counter)
+            log.debug("counter={0!r}".format(counter))
             self.inc_otp_counter(counter, reset=False)
             # At this point we must not bail out in case of an
             # Gateway error, since checkPIN is successful. A bail
@@ -254,7 +254,7 @@ class EmailTokenClass(HotpTokenClass):
                 info = ("The PIN was correct, but the "
                         "EMail could not be sent: %r" % e)
                 log.warning(info)
-                log.debug("%s" % traceback.format_exc(e))
+                log.debug("{0!s}".format(traceback.format_exc(e)))
                 return_message = info
 
         return success, return_message, transactionid, attributes
@@ -283,8 +283,8 @@ class EmailTokenClass(HotpTokenClass):
                 self.inc_otp_counter(ret, reset=False)
                 success, message = self._compose_email(message=message,
                                                     subject=subject)
-                log.debug("AutoEmail: send new SMS: %s" % success)
-                log.debug("AutoEmail: %s" % message)
+                log.debug("AutoEmail: send new SMS: {0!s}".format(success))
+                log.debug("AutoEmail: {0!s}".format(message))
         return ret
 
     @staticmethod
@@ -382,7 +382,7 @@ class EmailTokenClass(HotpTokenClass):
         subject = subject.replace("<otp>", otp)
         subject = subject.replace("<serial>", serial)
 
-        log.debug("sending Email to %s " % recipient)
+        log.debug("sending Email to {0!s} ".format(recipient))
 
         identifier = get_from_config("email.identifier")
         if identifier:

--- a/privacyidea/lib/tokens/foureyestoken.py
+++ b/privacyidea/lib/tokens/foureyestoken.py
@@ -154,7 +154,7 @@ class FourEyesTokenClass(TokenClass):
         if type(realms) is dict:
             for realmname, v in realms.items():
                 if v.get("selected"):
-                    realms_string += "%s:%s," % (realmname, v.get("count"))
+                    realms_string += "{0!s}:{1!s},".format(realmname, v.get("count"))
             if realms_string[-1] == ',':
                 realms_string = realms_string[:-1]
         else:
@@ -250,7 +250,7 @@ class FourEyesTokenClass(TokenClass):
             found_serials[realm] = list(set(found_serials[realm]))
 
             if len(found_serials[realm]) < required_realms[realm]:
-                reply = {"foureyes": "Only found %i tokens in realm %s" % (
+                reply = {"foureyes": "Only found {0:d} tokens in realm {1!s}".format(
                     len(found_serials[realm]), realm)}
                 otp_counter = -1
                 break

--- a/privacyidea/lib/tokens/hotptoken.py
+++ b/privacyidea/lib/tokens/hotptoken.py
@@ -193,8 +193,8 @@ class HotpTokenClass(TokenClass):
                                                                     width=250)
                                                   }
                 except Exception as ex:  # pragma: no cover
-                    log.error("%s" % (traceback.format_exc()))
-                    log.error('failed to set oath or google url: %r' % ex)
+                    log.error("{0!s}".format((traceback.format_exc())))
+                    log.error('failed to set oath or google url: {0!r}'.format(ex))
                     
         return response_detail
 
@@ -352,10 +352,10 @@ class HotpTokenClass(TokenClass):
             # we need to do this manually here:
             self.inc_otp_counter(res)
         if res == -1:
-            msg = "otp counter %r was not found" % otp
+            msg = "otp counter {0!r} was not found".format(otp)
         else:
-            msg = "otp counter %r was found" % otp
-        log.debug("end. %r: res %r" % (msg, res))
+            msg = "otp counter {0!r} was found".format(otp)
+        log.debug("end. {0!r}: res {1!r}".format(msg, res))
         return res
 
     @log_with(log)
@@ -404,7 +404,7 @@ class HotpTokenClass(TokenClass):
 
         # if _autosync is not enabled
         if autosync is False:
-            log.debug("end. _autosync is not enabled : res %r" % (res))
+            log.debug("end. _autosync is not enabled : res {0!r}".format((res)))
             return res
 
         info = self.get_tokeninfo()
@@ -476,7 +476,7 @@ class HotpTokenClass(TokenClass):
         counter = hmac2Otp.checkOtp(otp1, syncWindow)
 
         if counter == -1:
-            log.debug("exit. First counter (-1) not found  ret: %r" % (ret))
+            log.debug("exit. First counter (-1) not found  ret: {0!r}".format((ret)))
             return ret
 
         nextOtp = hmac2Otp.generate(counter + 1)
@@ -489,7 +489,7 @@ class HotpTokenClass(TokenClass):
         ret = True
         self.inc_otp_counter(counter + 1, True)
 
-        log.debug("end. resync was successful: ret: %r" % (ret))
+        log.debug("end. resync was successful: ret: {0!r}".format((ret)))
         return ret
 
     @staticmethod
@@ -503,8 +503,7 @@ class HotpTokenClass(TokenClass):
         try:
             timeOut = int(get_from_config("AutoResyncTimeout", 5 * 60))
         except Exception as ex:
-            log.warning("AutoResyncTimeout: value error %r - reset to 5*60"
-                        % (ex))
+            log.warning("AutoResyncTimeout: value error {0!r} - reset to 5*60".format((ex)))
             timeOut = 5 * 60
 
         return timeOut
@@ -528,10 +527,10 @@ class HotpTokenClass(TokenClass):
         otpval = hmac2Otp.generate(inc_counter=False)
 
         pin = self.token.get_pin()
-        combined = "%s%s" % (otpval, pin)
+        combined = "{0!s}{1!s}".format(otpval, pin)
 
         if get_from_config("PrependPin") == "True":
-            combined = "%s%s" % (pin, otpval)
+            combined = "{0!s}{1!s}".format(pin, otpval)
 
         return 1, pin, otpval, combined
 
@@ -561,7 +560,7 @@ class HotpTokenClass(TokenClass):
         secretHOtp = self.token.get_otpkey()
         hmac2Otp = HmacOtp(secretHOtp, self.token.count, otplen,
                            self.get_hashlib(self.hashlib))
-        log.debug("retrieving %i OTP values for token %s" % (count, hmac2Otp))
+        log.debug("retrieving {0:d} OTP values for token {1!s}".format(count, hmac2Otp))
 
         if count > 0:
             error = "OK"

--- a/privacyidea/lib/tokens/mOTP.py
+++ b/privacyidea/lib/tokens/mOTP.py
@@ -110,8 +110,7 @@ class mTimeOtp(object):
             otp = unicode(self.calcOtp(i, key, pin))
             if unicode(anOtpVal) == otp:
                 res = i
-                log.debug("otpvalue %r found at: %r" %
-                            (anOtpVal, res))
+                log.debug("otpvalue {0!r} found at: {1!r}".format(anOtpVal, res))
                 break
 
         if self.secretObject is not None:
@@ -122,15 +121,14 @@ class mTimeOtp(object):
 
         ## prevent access twice with last motp
         if res <= self.oldtime:
-            log.warning("otpvalue %s checked once before (%r<=%r)" %
-                        (anOtpVal, res, self.oldtime))
+            log.warning("otpvalue {0!s} checked once before ({1!r}<={2!r})".format(anOtpVal, res, self.oldtime))
             res = -1
         if res == -1:
             msg = 'checking motp failed'
         else:
             msg = 'checking motp sucess'
 
-        log.debug("end. %s : returning result: %r, " % (msg, res))
+        log.debug("end. {0!s} : returning result: {1!r}, ".format(msg, res))
         return res
 
     def calcOtp(self, counter, key=None, pin=None):
@@ -150,7 +148,7 @@ class mTimeOtp(object):
         if key is None:
             key = self.key
 
-        vhash = "%d%s%s" % (counter, key, pin)
+        vhash = "{0:d}{1!s}{2!s}".format(counter, key, pin)
         motp = md5(vhash).hexdigest()[:self.digits]
         return motp
 

--- a/privacyidea/lib/tokens/motptoken.py
+++ b/privacyidea/lib/tokens/motptoken.py
@@ -145,8 +145,8 @@ class MotpTokenClass(TokenClass):
                                                                     width=250)
                                                   }
                 except Exception as ex:   # pragma: no cover
-                    log.debug("%s" % traceback.format_exc())
-                    log.error('failed to set motp url: %r' % ex)
+                    log.debug("{0!s}".format(traceback.format_exc()))
+                    log.error('failed to set motp url: {0!r}'.format(ex))
                     
         return response_detail
 

--- a/privacyidea/lib/tokens/ocra.py
+++ b/privacyidea/lib/tokens/ocra.py
@@ -80,7 +80,7 @@ class OCRASuite(object):
         self.sha = hotp_sha_trunc[1]
         self.truncation = int(hotp_sha_trunc[2])
         if hotp != "HOTP":
-            raise Exception("Only HOTP is allowed. You specified %s" % hotp)
+            raise Exception("Only HOTP is allowed. You specified {0!s}".format(hotp))
         if self.sha not in ["SHA1", "SHA256", "SHA512"]:
             raise Exception("Only SHA1, SHA256 or SHA512 is allowed. You "
                             "specified %s" % self.sha)
@@ -252,12 +252,12 @@ class OCRA(object):
                 counter = struct.pack('>Q', int(counter))
                 data_input += counter
             else:
-                raise Exception("The ocrasuite %s requires a counter" %
-                                self.ocrasuite)
+                raise Exception("The ocrasuite {0!s} requires a counter".format(
+                                self.ocrasuite))
         # Check for Question
         if self.ocrasuite_obj.challenge_type == "QN":
             # In case of QN
-            question = '%x' % int(question)
+            question = '{0:x}'.format(int(question))
             question += '0' * (len(question) % 2)
             question = binascii.unhexlify(question)
             question += '\0' * (128-len(question))
@@ -278,12 +278,12 @@ class OCRA(object):
                     pin).digest()
                 data_input += pin_hash
             else:
-                raise Exception("The ocrasuite %s requires a PIN!" %
-                                self.ocrasuite)
+                raise Exception("The ocrasuite {0!s} requires a PIN!".format(
+                                self.ocrasuite))
         elif self.ocrasuite_obj.signature_type == "T":
             if not timesteps:
-                raise Exception("The ocrasuite %s requires timesteps" %
-                                self.ocrasuite)
+                raise Exception("The ocrasuite {0!s} requires timesteps".format(
+                                self.ocrasuite))
             # In case of Time
             timesteps = int(timesteps, 16)
             timesteps = struct.pack('>Q', int(timesteps))

--- a/privacyidea/lib/tokens/questionnairetoken.py
+++ b/privacyidea/lib/tokens/questionnairetoken.py
@@ -231,8 +231,8 @@ class QuestionnaireTokenClass(TokenClass):
         if answer == given_answer:
             res = 1
         else:
-            log.debug("The answer for token %s does not match." %
-                      self.get_serial())
+            log.debug("The answer for token {0!s} does not match.".format(
+                      self.get_serial()))
         return res
 
     @check_token_locked

--- a/privacyidea/lib/tokens/radiustoken.py
+++ b/privacyidea/lib/tokens/radiustoken.py
@@ -157,7 +157,7 @@ class RadiusTokenClass(RemoteTokenClass):
 
         if 1 == int(self.get_tokeninfo("radius.local_checkpin")):
             local_check = True
-        log.debug("local checking pin? %r" % local_check)
+        log.debug("local checking pin? {0!r}".format(local_check))
 
         return local_check
 
@@ -203,7 +203,7 @@ class RadiusTokenClass(RemoteTokenClass):
             radius_server_object = get_radius(radius_identifier)
             radius_server = radius_server_object.config.server
             radius_port = radius_server_object.config.port
-            radius_server = "%s:%s" % (radius_server, radius_port)
+            radius_server = "{0!s}:{1!s}".format(radius_server, radius_port)
             radius_secret = radius_server_object.get_secret()
             radius_dictionary = radius_server_object.config.dictionary
 
@@ -221,8 +221,7 @@ class RadiusTokenClass(RemoteTokenClass):
             radius_secret = binascii.unhexlify(secret.getKey())
 
         # here we also need to check for radius.user
-        log.debug("checking OTP len:%s on radius server: %s, user: %s" 
-                  % (len(otpval), radius_server, radius_user))
+        log.debug("checking OTP len:{0!s} on radius server: {1!s}, user: {2!s}".format(len(otpval), radius_server, radius_user))
 
         try:
             # pyrad does not allow to set timeout and retries.
@@ -286,8 +285,8 @@ class RadiusTokenClass(RemoteTokenClass):
                             (r_server, radius_user))
 
         except Exception as ex:  # pragma: no cover
-            log.error("Error contacting radius Server: %r" % (ex))
-            log.debug("%s" % traceback.format_exc())
+            log.error("Error contacting radius Server: {0!r}".format((ex)))
+            log.debug("{0!s}".format(traceback.format_exc()))
 
         return otp_count
 

--- a/privacyidea/lib/tokens/remotetoken.py
+++ b/privacyidea/lib/tokens/remotetoken.py
@@ -164,7 +164,7 @@ class RemoteTokenClass(TokenClass):
         local_check = False
         if 1 == int(self.get_tokeninfo("remote.local_checkpin")):
             local_check = True
-        log.debug(" local checking pin? %r" % local_check)
+        log.debug(" local checking pin? {0!r}".format(local_check))
 
         return local_check
 
@@ -275,7 +275,7 @@ class RemoteTokenClass(TokenClass):
             return otp_count
 
         params['pass'] = otpval
-        request_url = "%s%s" % (remoteServer, remotePath)
+        request_url = "{0!s}{1!s}".format(remoteServer, remotePath)
 
         try:
             r = requests.post(request_url, data=params, verify=ssl_verify)
@@ -289,7 +289,7 @@ class RemoteTokenClass(TokenClass):
         except Exception as exx:  # pragma: no cover
             log.error("Error getting response from "
                       "remote Server (%r): %r" % (request_url, exx))
-            log.debug("%s" % traceback.format_exc())
+            log.debug("{0!s}".format(traceback.format_exc()))
 
         return otp_count
 

--- a/privacyidea/lib/tokens/smstoken.py
+++ b/privacyidea/lib/tokens/smstoken.py
@@ -269,7 +269,7 @@ class SmsTokenClass(HotpTokenClass):
 
         if self.is_active() is True:
             counter = self.get_otp_count()
-            log.debug("counter=%r" % counter)
+            log.debug("counter={0!r}".format(counter))
             self.inc_otp_counter(counter, reset=False)
             # At this point we must not bail out in case of an
             # Gateway error, since checkPIN is successful. A bail
@@ -296,7 +296,7 @@ class SmsTokenClass(HotpTokenClass):
         validity = self._get_sms_timeout()
         expiry_date = datetime.datetime.now() + \
                                     datetime.timedelta(seconds=validity)
-        attributes['valid_until'] = "%s" % expiry_date
+        attributes['valid_until'] = "{0!s}".format(expiry_date)
 
         return success, return_message, transactionid, attributes
 
@@ -320,8 +320,8 @@ class SmsTokenClass(HotpTokenClass):
                 message = self._get_sms_text(options)
                 self.inc_otp_counter(ret, reset=False)
                 success, message = self._send_sms(message=message)
-                log.debug("AutoSMS: send new SMS: %s" % success)
-                log.debug("AutoSMS: %s" % message)
+                log.debug("AutoSMS: send new SMS: {0!s}".format(success))
+                log.debug("AutoSMS: {0!s}".format(message))
         return ret
 
     @log_with(log)
@@ -345,30 +345,30 @@ class SmsTokenClass(HotpTokenClass):
         message = message.replace("<otp>", otp)
         message = message.replace("<serial>", serial)
 
-        log.debug("sending SMS to phone number %s " % phone)
+        log.debug("sending SMS to phone number {0!s} ".format(phone))
         (SMSProvider, SMSProviderClass) = self._get_sms_provider()
-        log.debug("smsprovider: %s, class: %s" % (SMSProvider,
+        log.debug("smsprovider: {0!s}, class: {1!s}".format(SMSProvider,
                                                   SMSProviderClass))
 
         try:
             sms = get_sms_provider_class(SMSProvider, SMSProviderClass)()
         except Exception as exc:
-            log.error("Failed to load SMSProvider: %r" % exc)
-            log.debug("%s" % traceback.format_exc())
+            log.error("Failed to load SMSProvider: {0!r}".format(exc))
+            log.debug("{0!s}".format(traceback.format_exc()))
             raise exc
 
         try:
             # now we need the config from the env
-            log.debug("loading SMS configuration for class %s" % sms)
+            log.debug("loading SMS configuration for class {0!s}".format(sms))
             config = self._get_sms_provider_config()
-            log.debug("config: %r" % config)
+            log.debug("config: {0!r}".format(config))
             sms.load_config(config)
         except Exception as exc:
-            log.error("Failed to load sms.providerConfig: %r" % exc)
-            log.debug("%s" % traceback.format_exc())
-            raise Exception("Failed to load sms.providerConfig: %r" % exc)
+            log.error("Failed to load sms.providerConfig: {0!r}".format(exc))
+            log.debug("{0!s}".format(traceback.format_exc()))
+            raise Exception("Failed to load sms.providerConfig: {0!r}".format(exc))
 
-        log.debug("submitMessage: %r, to phone %r" % (message, phone))
+        log.debug("submitMessage: {0!r}, to phone {1!r}".format(message, phone))
         ret = sms.submit_message(phone, message)
         return ret, message
 
@@ -412,8 +412,7 @@ class SmsTokenClass(HotpTokenClass):
         try:
             timeout = int(get_from_config("sms.providerTimeout", 5 * 60))
         except Exception as ex:  # pragma: no cover
-            log.warning("SMSProviderTimeout: value error %r - reset to 5*60"
-                                                                        % (ex))
+            log.warning("SMSProviderTimeout: value error {0!r} - reset to 5*60".format((ex)))
             timeout = 5 * 60
         return timeout
 

--- a/privacyidea/lib/tokens/sshkeytoken.py
+++ b/privacyidea/lib/tokens/sshkeytoken.py
@@ -143,4 +143,4 @@ class SSHkeyTokenClass(TokenClass):
         key_comment = ti.get("ssh_comment")
         # get the ssh key directly, otherwise it will not be decrypted
         sshkey = self.get_tokeninfo("ssh_key")
-        return "%s %s %s" % (key_type, sshkey, key_comment)
+        return "{0!s} {1!s} {2!s}".format(key_type, sshkey, key_comment)

--- a/privacyidea/lib/tokens/tiqrtoken.py
+++ b/privacyidea/lib/tokens/tiqrtoken.py
@@ -203,12 +203,12 @@ class TiqrTokenClass(TokenClass):
         response_detail = TokenClass.get_init_detail(self, params, user)
         params = params or {}
         enroll_url = get_from_config("tiqr.regServer")
-        log.info("using tiqr.regServer for enrollment: %s" % enroll_url)
+        log.info("using tiqr.regServer for enrollment: {0!s}".format(enroll_url))
         serial = self.token.serial
         session = generate_otpkey()
         # save the session in the token
         self.add_tokeninfo("session", session)
-        tiqrenroll = "tiqrenroll://%s?action=%s&session=%s&serial=%s" % (
+        tiqrenroll = "tiqrenroll://{0!s}?action={1!s}&session={2!s}&serial={3!s}".format(
             enroll_url, API_ACTIONS.METADATA,
             session, serial)
 
@@ -236,8 +236,8 @@ class TiqrTokenClass(TokenClass):
         action = getParam(params, "action", optional) or \
                  API_ACTIONS.AUTHENTICATION
         if action not in API_ACTIONS.ALLOWED_ACTIONS:
-            raise ParameterError("Allowed actions are %s" %
-                                 API_ACTIONS.ALLOWED_ACTIONS)
+            raise ParameterError("Allowed actions are {0!s}".format(
+                                 API_ACTIONS.ALLOWED_ACTIONS))
 
         if action == API_ACTIONS.METADATA:
             session = getParam(params, "session", required)
@@ -246,7 +246,7 @@ class TiqrTokenClass(TokenClass):
             # We need to set the user ID
             tokens = get_tokens(serial=serial)
             if not tokens:  # pragma: no cover
-                raise ParameterError("No token with serial %s" % serial)
+                raise ParameterError("No token with serial {0!s}".format(serial))
             user_identifier, user_displayname = tokens[0].get_user_displayname()
 
             service_identifier = get_from_config("tiqr.serviceIdentifier") or\
@@ -263,10 +263,10 @@ class TiqrTokenClass(TokenClass):
                        "logoUrl": logo_url,
                        "infoUrl": "https://www.privacyidea.org",
                        "authenticationUrl":
-                           "%s" % auth_server,
+                           "{0!s}".format(auth_server),
                        "ocraSuite": ocrasuite,
                        "enrollmentUrl":
-                           "%s?action=%s&session=%s&serial=%s" % (
+                           "{0!s}?action={1!s}&session={2!s}&serial={3!s}".format(
                                reg_server,
                                API_ACTIONS.ENROLLMENT,
                                session, serial)
@@ -418,7 +418,7 @@ class TiqrTokenClass(TokenClass):
                                  validitytime=validity)
         db_challenge.save()
 
-        authurl = "tiqrauth://%s@%s/%s/%s" % (user_identifier,
+        authurl = "tiqrauth://{0!s}@{1!s}/{2!s}/{3!s}".format(user_identifier,
                                               service_identifier,
                                               db_challenge.transaction_id,
                                               challenge)

--- a/privacyidea/lib/tokens/totptoken.py
+++ b/privacyidea/lib/tokens/totptoken.py
@@ -344,14 +344,13 @@ class TotpTokenClass(HotpTokenClass):
             lastauth = self._counter2time(oCount, self.timestep)
             lastauthDt = datetime.datetime.fromtimestamp(lastauth / 1.0)
 
-            log.debug("last auth : %r" % lastauthDt)
-            log.debug("tokentime : %r" % tokenDt)
-            log.debug("now       : %r" % nowDt)
-            log.debug("delta     : %r" % (tokentime - inow))
+            log.debug("last auth : {0!r}".format(lastauthDt))
+            log.debug("tokentime : {0!r}".format(tokenDt))
+            log.debug("now       : {0!r}".format(nowDt))
+            log.debug("delta     : {0!r}".format((tokentime - inow)))
 
             new_shift = (tokentime - inow)
-            log.debug("the counter %r matched. New shift: %r" %
-                      (res, new_shift))
+            log.debug("the counter {0!r} matched. New shift: {1!r}".format(res, new_shift))
             self.add_tokeninfo('timeShift', new_shift)
         return res
 
@@ -391,8 +390,7 @@ class TotpTokenClass(HotpTokenClass):
 
         # check if the otpval is valid in the sync scope
         res = hmac2Otp.checkOtp(anOtpVal, syncWindow, symetric=True)
-        log.debug("found otpval %r in syncwindow (%r): %r" %
-                  (anOtpVal, syncWindow, res))
+        log.debug("found otpval {0!r} in syncwindow ({1!r}): {2!r}".format(anOtpVal, syncWindow, res))
 
         if res != -1:
             # if former is defined
@@ -400,7 +398,7 @@ class TotpTokenClass(HotpTokenClass):
                 # check if this is consecutive
                 otp1c = int(info.get("otp1c"))
                 otp2c = res
-                log.debug("otp1c: %r, otp2c: %r" % (otp1c, otp2c))
+                log.debug("otp1c: {0!r}, otp2c: {1!r}".format(otp1c, otp2c))
                 diff = math.fabs(otp2c - otp1c)
                 if diff > self.resyncDiffLimit:
                     res = -1
@@ -417,7 +415,7 @@ class TotpTokenClass(HotpTokenClass):
                 self.set_tokeninfo(info)
 
             else:
-                log.debug("setting otp1c: %s" % res)
+                log.debug("setting otp1c: {0!s}".format(res))
                 info["otp1c"] = res
                 self.set_tokeninfo(info)
                 res = -1
@@ -444,8 +442,7 @@ class TotpTokenClass(HotpTokenClass):
         otplen = int(self.token.otplen)
         secretHOtp = self.token.get_otpkey()
 
-        log.debug("timestep: %r, syncWindow: %r, timeShift: %r"
-                  % (self.timestep, self.timewindow, self.timeshift))
+        log.debug("timestep: {0!r}, syncWindow: {1!r}, timeShift: {2!r}".format(self.timestep, self.timewindow, self.timeshift))
 
         initTime = int(options.get('initTime', -1))
         if initTime != -1:
@@ -454,33 +451,32 @@ class TotpTokenClass(HotpTokenClass):
             server_time = time.time() + self.timeshift
 
         counter = int((server_time / self.timestep) + 0.5)
-        log.debug("counter (current time): %i" % counter)
+        log.debug("counter (current time): {0:d}".format(counter))
 
         oCount = self.get_otp_count()
 
-        log.debug("tokenCounter: %r" % oCount)
-        log.debug("now checking window %s, timeStepping %s" %
-                  (self.timewindow, self.timestep))
+        log.debug("tokenCounter: {0!r}".format(oCount))
+        log.debug("now checking window {0!s}, timeStepping {1!s}".format(self.timewindow, self.timestep))
         # check 2nd value
         hmac2Otp = HmacOtp(secretHOtp,
                            counter,
                            otplen,
                            self.get_hashlib(self.hashlib))
-        log.debug("%s in otpkey: %s " % (otp2, secretHOtp))
+        log.debug("{0!s} in otpkey: {1!s} ".format(otp2, secretHOtp))
         res2 = hmac2Otp.checkOtp(otp2,
                                  int(self.timewindow / self.timestep),
                                  symetric=True)  # TEST -remove the 10
-        log.debug("res 2: %r" % res2)
+        log.debug("res 2: {0!r}".format(res2))
         # check 1st value
         hmac2Otp = HmacOtp(secretHOtp,
                            counter - 1,
                            otplen,
                            self.get_hashlib(self.hashlib))
-        log.debug("%s in otpkey: %s " % (otp1, secretHOtp))
+        log.debug("{0!s} in otpkey: {1!s} ".format(otp1, secretHOtp))
         res1 = hmac2Otp.checkOtp(otp1,
                                  int(self.timewindow / self.timestep),
                                  symetric=True)  # TEST -remove the 10
-        log.debug("res 1: %r" % res1)
+        log.debug("res 1: {0!r}".format(res1))
 
         if res1 < oCount:
             # A previous OTP value was used again!
@@ -495,8 +491,7 @@ class TotpTokenClass(HotpTokenClass):
             tokentime = (res2 + 0.5) * self.timestep
             currenttime = server_time - self.timeshift
             new_shift = (tokentime - currenttime)
-            log.debug("the counters %r and %r matched. New shift: %r"
-                      % (res1, res2, new_shift))
+            log.debug("the counters {0!r} and {1!r} matched. New shift: {2!r}".format(res1, res2, new_shift))
             self.add_tokeninfo('timeShift', new_shift)
 
             # The OTP value that was used for resync must not be used again!
@@ -509,7 +504,7 @@ class TotpTokenClass(HotpTokenClass):
         else:
             msg = "resync was not successful"
 
-        log.debug("end. %s: ret: %r" % (msg, ret))
+        log.debug("end. {0!s}: ret: {1!r}".format(msg, ret))
         return ret
 
     def get_otp(self, current_time=None, do_truncation=True,
@@ -547,9 +542,9 @@ class TotpTokenClass(HotpTokenClass):
                                    challenge=challenge)
 
         pin = self.token.get_pin()
-        combined = "%s%s" % (otpval, pin)
+        combined = "{0!s}{1!s}".format(otpval, pin)
         if get_from_config("PrependPin") == "True":
-            combined = "%s%s" % (pin, otpval)
+            combined = "{0!s}{1!s}".format(pin, otpval)
             
         return 1, pin, otpval, combined
 

--- a/privacyidea/lib/tokens/u2f.py
+++ b/privacyidea/lib/tokens/u2f.py
@@ -112,7 +112,7 @@ def parse_registration_data(reg_data):
                                            attestation_cert))
     # TODO: Check the issuer of the certificate
     issuer = attestation_cert.get_issuer()
-    log.debug("The attestation certificate is signed by %s" % issuer)
+    log.debug("The attestation certificate is signed by {0!s}".format(issuer))
     not_after = attestation_cert.get_notAfter()
     not_before = attestation_cert.get_notBefore()
     log.debug("The attestation certificate "
@@ -122,7 +122,7 @@ def parse_registration_data(reg_data):
     # check the validity period of the certificate
     if start_time > time.localtime() or \
                     end_time < time.localtime():  #pragma no cover
-        log.error("The certificate is not valid. %s -> %s" % (not_before,
+        log.error("The certificate is not valid. {0!s} -> {1!s}".format(not_before,
                                                               not_after))
         raise Exception("The time of the attestation certificate is not "
                         "valid.")
@@ -268,7 +268,7 @@ def check_response(user_pub_key, app_id, client_data, signature,
     try:
         vkey.verify(signature_bin_asn, input_data)
     except ecdsa.BadSignatureError:
-        log.error("Bad signature for app_id %s" % app_id)
+        log.error("Bad signature for app_id {0!s}".format(app_id))
         res = False
     return res
 

--- a/privacyidea/lib/tokens/u2ftoken.py
+++ b/privacyidea/lib/tokens/u2ftoken.py
@@ -362,8 +362,8 @@ class U2fTokenClass(TokenClass):
         additional ``attributes``, which are displayed in the JSON response.
         """
         options = options or {}
-        message = 'Please confirm with your U2F token (%s)' % \
-                  self.token.description
+        message = 'Please confirm with your U2F token ({0!s})'.format( \
+                  self.token.description)
 
         validity = int(get_from_config('DefaultChallengeValidityTime', 120))
         tokentype = self.get_tokentype().lower()
@@ -444,8 +444,8 @@ class U2fTokenClass(TokenClass):
                     log.warning("The signature of %s was valid, but contained "
                                 "an old counter." % self.token.serial)
             else:
-                log.warning("Checking response for token %s failed." %
-                            self.token.serial)
+                log.warning("Checking response for token {0!s} failed.".format(
+                            self.token.serial))
 
         return ret
 
@@ -467,10 +467,10 @@ class U2fTokenClass(TokenClass):
         pol_facets = g.policy_object.get_action_values(U2FACTION.FACETS,
                                                        scope=SCOPE.AUTH,
                                                        client=g.client_ip)
-        facet_list = ["https://%s" % x for x in pol_facets]
+        facet_list = ["https://{0!s}".format(x) for x in pol_facets]
         facet_list.append(app_id)
 
-        log.debug("Sending facets lists for appId %s: %s" % (app_id,
+        log.debug("Sending facets lists for appId {0!s}: {1!s}".format(app_id,
                                                              facet_list))
         res = {"trustedFacets": [{"version": {"major": 1,
                                               "minor": 0},

--- a/privacyidea/lib/tokens/yubicotoken.py
+++ b/privacyidea/lib/tokens/yubicotoken.py
@@ -118,8 +118,8 @@ class YubicoTokenClass(TokenClass):
     def update(self, param):
         tokenid = getParam(param, "yubico.tokenid", required)
         if len(tokenid) < YUBICO_LEN_ID:
-            log.error("The tokenid needs to be %i characters long!" % YUBICO_LEN_ID)
-            raise Exception("The Yubikey token ID needs to be %i characters long!" % YUBICO_LEN_ID)
+            log.error("The tokenid needs to be {0:d} characters long!".format(YUBICO_LEN_ID))
+            raise Exception("The Yubikey token ID needs to be {0:d} characters long!".format(YUBICO_LEN_ID))
 
         if len(tokenid) > YUBICO_LEN_ID:
             tokenid = tokenid[:YUBICO_LEN_ID]
@@ -150,7 +150,7 @@ class YubicoTokenClass(TokenClass):
 
         tokenid = self.get_tokeninfo("yubico.tokenid")
         if len(anOtpVal) < 12:
-            log.warning("The otpval is too short: %r" % anOtpVal)
+            log.warning("The otpval is too short: {0!r}".format(anOtpVal))
         elif anOtpVal[:12] != tokenid:
             log.warning("The tokenid in the OTP value does not match "
                         "the assigned token!")
@@ -194,11 +194,11 @@ class YubicoTokenClass(TokenClass):
                     else:
                         # possible results are listed here:
                         # https://github.com/Yubico/yubikey-val/wiki/ValidationProtocolV20
-                        log.warning("failed with %r" % result)
+                        log.warning("failed with {0!r}".format(result))
 
             except Exception as ex:
                 log.error("Error getting response from Yubico Cloud Server"
                           " (%r): %r" % (yubico_url, ex))
-                log.debug("%s" % traceback.format_exc())
+                log.debug("{0!s}".format(traceback.format_exc()))
 
         return res

--- a/privacyidea/lib/tokens/yubikeytoken.py
+++ b/privacyidea/lib/tokens/yubikeytoken.py
@@ -91,7 +91,7 @@ def yubico_api_signature(data, api_key):
     keys = sorted(r.keys())
     data_string = ""
     for key in keys:
-        data_string += "%s=%s&" % (key, r.get(key))
+        data_string += "{0!s}={1!s}&".format(key, r.get(key))
     data_string = data_string.strip("&")
     api_key_bin = base64.b64decode(api_key)
     # generate the signature
@@ -270,14 +270,14 @@ class YubikeyTokenClass(TokenClass):
         # CRC-16 checksum of the whole decrypted OTP should give a fixed
         # residual
         # of 0xf0b8 (see Yubikey-Manual - Chapter 6: Implementation details).
-        log.debug("calculated checksum (61624): %r" % checksum(msg_hex))
+        log.debug("calculated checksum (61624): {0!r}".format(checksum(msg_hex)))
         if checksum(msg_hex) != 0xf0b8:  # pragma: no cover
-            log.warning("CRC checksum for token %r failed" % serial)
+            log.warning("CRC checksum for token {0!r} failed".format(serial))
             return -3
 
         uid = msg_hex[0:12]
-        log.debug("uid: %r" % uid)
-        log.debug("prefix: %r" % binascii.hexlify(modhex_decode(yubi_prefix)))
+        log.debug("uid: {0!r}".format(uid))
+        log.debug("prefix: {0!r}".format(binascii.hexlify(modhex_decode(yubi_prefix))))
         # usage_counter can go from 1 – 0x7fff
         usage_counter = msg_hex[12:16]
         timestamp = msg_hex[16:22]
@@ -285,25 +285,24 @@ class YubikeyTokenClass(TokenClass):
         session_counter = msg_hex[22:24]
         random = msg_hex[24:28]
         crc = msg_hex[28:]
-        log.debug("decrypted: usage_count: %r, session_count: %r" %
-                  (usage_counter, session_counter))
+        log.debug("decrypted: usage_count: {0!r}, session_count: {1!r}".format(usage_counter, session_counter))
 
         # create the counter as integer
         # Note: The usage counter is stored LSB!
 
         count_hex = usage_counter[2:4] + usage_counter[0:2] + session_counter
         count_int = int(count_hex, 16)
-        log.debug('decrypted counter: %r' % count_int)
+        log.debug('decrypted counter: {0!r}'.format(count_int))
 
         tokenid = self.get_tokeninfo("yubikey.tokenid")
         if not tokenid:
-            log.debug("Got no tokenid for %r. Setting to %r." % (serial, uid))
+            log.debug("Got no tokenid for {0!r}. Setting to {1!r}.".format(serial, uid))
             tokenid = uid
             self.add_tokeninfo("yubikey.tokenid", tokenid)
 
         prefix = self.get_tokeninfo("yubikey.prefix")
         if not prefix:
-            log.debug("Got no prefix for %r. Setting to %r." % (serial, yubi_prefix))
+            log.debug("Got no prefix for {0!r}. Setting to {1!r}.".format(serial, yubi_prefix))
             self.add_tokeninfo("yubikey.prefix", yubi_prefix)
 
         if tokenid != uid:
@@ -315,7 +314,7 @@ class YubikeyTokenClass(TokenClass):
 
         # TODO: We also could check the timestamp
         # see http://www.yubico.com/wp-content/uploads/2013/04/YubiKey-Manual-v3_1.pdf
-        log.debug('compare counter to database counter: %r' % self.token.count)
+        log.debug('compare counter to database counter: {0!r}'.format(self.token.count))
         if count_int >= self.token.count:
             res = count_int
             # on success we save the used counter
@@ -331,7 +330,7 @@ class YubikeyTokenClass(TokenClass):
         :param api_id: The base64 encoded API ID
         :return: the base64 encoded API Key or None
         """
-        api_key = get_from_config("yubikey.apiid.%s" % api_id)
+        api_key = get_from_config("yubikey.apiid.{0!s}".format(api_id))
         return api_key
 
     @classmethod
@@ -431,11 +430,11 @@ h={h}
                 # Keep the backward compatibility
                 serialnum = "UBAM" + modhex_decode(prefix)
                 for i in range(1, 3):
-                    s = "%s_%s" % (serialnum, i)
+                    s = "{0!s}_{1!s}".format(serialnum, i)
                     toks = get_tokens(serial=s)
                     token_list.extend(toks)
             except TypeError as exx:  # pragma: no cover
-                log.error("Failed to convert serialnumber: %r" % exx)
+                log.error("Failed to convert serialnumber: {0!r}".format(exx))
 
         # Now, we see, if the prefix matches the new version
         if not token_list:
@@ -447,8 +446,8 @@ h={h}
             token_list.extend(token_candidate_list)
 
         if not token_list:
-            opt['action_detail'] = ("The prefix %s could not be found!" %
-                                    prefix)
+            opt['action_detail'] = ("The prefix {0!s} could not be found!".format(
+                                    prefix))
             return res, opt
 
         (res, opt) = check_token_list(token_list, passw)

--- a/privacyidea/lib/user.py
+++ b/privacyidea/lib/user.py
@@ -125,14 +125,13 @@ class User(object):
 
             conf = ''
             if self.resolver is not None and self.resolver:
-                conf = '.%s' % (unicode(self.resolver))
-            ret = '<%s%s@%s>' % (loginname, conf, unicode(self.realm))
+                conf = '.{0!s}'.format((unicode(self.resolver)))
+            ret = '<{0!s}{1!s}@{2!s}>'.format(loginname, conf, unicode(self.realm))
 
         return ret
 
     def __repr__(self):
-        ret = ('User(login=%r, realm=%r, resolver=%r)' %
-               (self.login, self.realm, self.resolver))
+        ret = ('User(login={0!r}, realm={1!r}, resolver={2!r})'.format(self.login, self.realm, self.resolver))
         return ret
     
     @log_with(log)
@@ -180,17 +179,17 @@ class User(object):
             # test, if the user is contained in this resolver
             y = get_resolver_object(resolvername)
             if y is None:  # pragma: no cover
-                log.info("Resolver %r not found!" % resolvername)
+                log.info("Resolver {0!r} not found!".format(resolvername))
             else:
                 uid = y.getUserId(self.login)
                 if uid not in ["", None]:
-                    log.info("user %r found in resolver %r" % (self.login,
+                    log.info("user {0!r} found in resolver {1!r}".format(self.login,
                                                                resolvername))
-                    log.info("userid resolved to %r " % uid)
+                    log.info("userid resolved to {0!r} ".format(uid))
                     priority = resolvers_in_realm.get(resolvername).get(
                         "priority", 999)
-                    log.debug("priority of the resolver is %s" % priority)
-                    log.debug("The highest priority is %s" % highest_priority)
+                    log.debug("priority of the resolver is {0!s}".format(priority))
+                    log.debug("The highest priority is {0!s}".format(highest_priority))
                     if priority < highest_priority:
                         highest_priority = priority
                         resolver_with_highest_priority = resolvername
@@ -222,8 +221,8 @@ class User(object):
         rtype = get_resolver_type(self.resolver)
         y = get_resolver_object(self.resolver)
         if y is None:
-            raise UserError("The resolver '%s' does not exist!" %
-                            self.resolver)
+            raise UserError("The resolver '{0!s}' does not exist!".format(
+                            self.resolver))
         uid = y.getUserId(self.login)
         return uid, rtype, self.resolver
 
@@ -236,7 +235,7 @@ class User(object):
         try:
             uid, _rtype, _resolver = self.get_user_identifiers()
         except UserError:
-            log.debug("User %s does not exist." % self)
+            log.debug("User {0!s} does not exist.".format(self))
             success = False
         if not uid:
             # The SQL resolver does not raise an exception but returns an
@@ -270,12 +269,10 @@ class User(object):
         """
         userinfo = self.info
         if phone_type in userinfo:
-            log.debug("got user phone %r of type %r"
-                      % (userinfo[phone_type], phone_type))
+            log.debug("got user phone {0!r} of type {1!r}".format(userinfo[phone_type], phone_type))
             return userinfo[phone_type]
         else:
-            log.warning("userobject (%r) has no phone of type %r."
-                        % (self, phone_type))
+            log.warning("userobject ({0!r}) has no phone of type {1!r}.".format(self, phone_type))
             return ""
 
     @log_with(log)
@@ -303,7 +300,7 @@ class User(object):
             # we have got a resolver and will get all realms
             # the resolver belongs to.
             for key, val in allRealms.items():
-                log.debug("evaluating realm %r: %r " % (key, val))
+                log.debug("evaluating realm {0!r}: {1!r} ".format(key, val))
                 for reso in val.get('resolver', []):
                     resoname = reso.get("name")
                     if resoname == self.resolver:
@@ -335,18 +332,18 @@ class User(object):
                 y = get_resolver_object(self.resolver)
                 uid, _rtype, _rname = self.get_user_identifiers()
                 if y.checkPass(uid, password):
-                    success = "%s@%s" % (self.login, self.realm)
-                    log.debug("Successfully authenticated user %r." % self)
+                    success = "{0!s}@{1!s}".format(self.login, self.realm)
+                    log.debug("Successfully authenticated user {0!r}.".format(self))
                 else:
-                    log.info("user %r failed to authenticate." % self)
+                    log.info("user {0!r} failed to authenticate.".format(self))
 
             elif not res:
-                log.error("The user %r exists in NO resolver." % self)
+                log.error("The user {0!r} exists in NO resolver.".format(self))
         except UserError as e:  # pragma: no cover
-            log.error("Error while trying to verify the username: %r" % e)
+            log.error("Error while trying to verify the username: {0!r}".format(e))
         except Exception as e:  # pragma: no cover
-            log.error("Error checking password within module %r" % e)
-            log.debug("%s" % traceback.format_exc())
+            log.error("Error checking password within module {0!r}".format(e))
+            log.debug("{0!s}".format(traceback.format_exc()))
     
         return success
     
@@ -369,7 +366,7 @@ class User(object):
                 searchFields[reso] = sf
     
             except Exception as e:  # pragma: no cover
-                log.warning("module %r: %r" % (reso, e))
+                log.warning("module {0!r}: {1!r}".format(reso, e))
     
         return searchFields
 
@@ -386,8 +383,7 @@ class User(object):
         """
         success = False
         try:
-            log.info("User info for user %s@%s about to be updated." %
-                     (self.login, self.realm))
+            log.info("User info for user {0!s}@{1!s} about to be updated.".format(self.login, self.realm))
             if type(self.login) != unicode:
                 self.login = self.login.decode(ENCODING)
             res = self.get_resolvers()
@@ -396,7 +392,7 @@ class User(object):
             if len(res) == 1:
                 y = get_resolver_object(self.resolver)
                 if not y.updateable:  # pragma: no cover
-                    log.warning("The resolver %s is not updateable." % y)
+                    log.warning("The resolver {0!s} is not updateable.".format(y))
                 else:
                     uid, _rtype, _rname = self.get_user_identifiers()
                     if y.update_user(uid, attributes):
@@ -404,14 +400,14 @@ class User(object):
                         # If necessary, update the username
                         if attributes.get("username"):
                             self.login = attributes.get("username")
-                        log.info("Successfully updated user %r." % self)
+                        log.info("Successfully updated user {0!r}.".format(self))
                     else:  # pragma: no cover
-                        log.info("user %r failed to update." % self)
+                        log.info("user {0!r} failed to update.".format(self))
 
             elif not res:  # pragma: no cover
-                log.error("The user %r exists in NO resolver." % self)
+                log.error("The user {0!r} exists in NO resolver.".format(self))
         except UserError as exx:  # pragma: no cover
-            log.error("Error while trying to verify the username: %s" % exx)
+            log.error("Error while trying to verify the username: {0!s}".format(exx))
 
         return success
 
@@ -425,8 +421,7 @@ class User(object):
         """
         success = False
         try:
-            log.info("User %s@%s about to be deleted." %
-                     (self.login, self.realm))
+            log.info("User {0!s}@{1!s} about to be deleted.".format(self.login, self.realm))
             if type(self.login) != unicode:
                 self.login = self.login.decode(ENCODING)
             res = self.get_resolvers()
@@ -434,22 +429,22 @@ class User(object):
             if len(res) == 1:
                 y = get_resolver_object(self.resolver)
                 if not y.updateable:  # pragma: no cover
-                    log.warning("The resolver %s is not updateable." % y)
+                    log.warning("The resolver {0!s} is not updateable.".format(y))
                 else:
                     uid, _rtype, _rname = self.get_user_identifiers()
                     if y.delete_user(uid):
                         success = True
-                        log.info("Successfully deleted user %r." % self)
+                        log.info("Successfully deleted user {0!r}.".format(self))
                     else:  # pragma: no cover
-                        log.info("user %r failed to update." % self)
+                        log.info("user {0!r} failed to update.".format(self))
 
             elif not res:  # pragma: no cover
-                log.error("The user %r exists in NO resolver." % self)
+                log.error("The user {0!r} exists in NO resolver.".format(self))
         except UserError as exx:  # pragma: no cover
-            log.error("Error while trying to verify the username: %r" % exx)
+            log.error("Error while trying to verify the username: {0!r}".format(exx))
         except Exception as exx:  # pragma: no cover
-            log.error("Error checking password within module %r" % exx)
-            log.debug("%s" % traceback.format_exc())
+            log.error("Error checking password within module {0!r}".format(exx))
+            log.debug("{0!s}".format(traceback.format_exc()))
 
         return success
 
@@ -573,7 +568,7 @@ def get_user_list(param=None, user=None):
             key = "username"
 
         searchDict[key] = lval
-        log.debug("Parameter key:%r=%r" % (key, lval))
+        log.debug("Parameter key:{0!r}={1!r}".format(key, lval))
 
     # determine which scope we want to show
     param_resolver = getParam(param, "resolver")
@@ -606,25 +601,25 @@ def get_user_list(param=None, user=None):
 
     for resolver_name in set(resolvers):
         try:
-            log.debug("Check for resolver class: %r" % resolver_name)
+            log.debug("Check for resolver class: {0!r}".format(resolver_name))
             y = get_resolver_object(resolver_name)
-            log.debug("with this search dictionary: %r " % searchDict)
+            log.debug("with this search dictionary: {0!r} ".format(searchDict))
             ulist = y.getUserList(searchDict)
             # Add resolvername to the list
             for ue in ulist:
                 ue["resolver"] = resolver_name
                 ue["editable"] = y.updateable
-            log.debug("Found this userlist: %r" % ulist)
+            log.debug("Found this userlist: {0!r}".format(ulist))
             users.extend(ulist)
 
         except KeyError as exx:  # pragma: no cover
-            log.error("%r" % (exx))
-            log.debug("%s" % traceback.format_exc())
+            log.error("{0!r}".format((exx)))
+            log.debug("{0!s}".format(traceback.format_exc()))
             raise exx
 
         except Exception as exx:  # pragma: no cover
-            log.error("%r" % (exx))
-            log.debug("%s" % traceback.format_exc())
+            log.error("{0!r}".format((exx)))
+            log.debug("{0!s}".format(traceback.format_exc()))
             continue
 
     return users

--- a/privacyidea/lib/utils.py
+++ b/privacyidea/lib/utils.py
@@ -26,7 +26,7 @@ def to_utf8(password):
         except UnicodeDecodeError as exx:
             # In case the password is already an encoded string, we fail to
             # encode it again...
-            log.debug("Failed to convert password: %s" % type(password))
+            log.debug("Failed to convert password: {0!s}".format(type(password)))
     return password
 
 
@@ -39,7 +39,7 @@ def generate_otpkey(key_size=20):
     :return: hexlified key
     :rtype: string
     """
-    log.debug("generating key of size %s" % key_size)
+    log.debug("generating key of size {0!s}".format(key_size))
     return binascii.hexlify(geturandom(key_size))
 
 
@@ -78,13 +78,13 @@ def create_img(data, width=0, alt=None, raw=False):
     data_uri = o_data.encode("base64").replace("\n", "")
 
     if width != 0:
-        width_str = " width=%d " % (int(width))
+        width_str = " width={0:d} ".format((int(width)))
 
     if alt is not None:
         val = urllib.urlencode({'alt': alt})
-        alt_str = " alt=%r " % (val[len('alt='):])
+        alt_str = " alt={0!r} ".format((val[len('alt='):]))
 
-    ret_img = 'data:image/png;base64,%s' % data_uri
+    ret_img = 'data:image/png;base64,{0!s}'.format(data_uri)
 
     return ret_img
 
@@ -205,8 +205,8 @@ def get_data_from_params(params, exclude_params, config_description, module,
         if t not in data:
             _missing = True
     if _missing:
-        raise Exception("type or description without necessary data! %s" %
-                        unicode(params))
+        raise Exception("type or description without necessary data! {0!s}".format(
+                        unicode(params)))
 
     return data, types, desc
 

--- a/privacyidea/models.py
+++ b/privacyidea/models.py
@@ -209,7 +209,7 @@ class Token(MethodsMixin, db.Model):
         self.key_enc = unicode(binascii.hexlify(enc_otp_key))
         length = len(self.key_enc)
         if length > 1024:
-            log.error("Key %s exceeds database field %d!" % (self.get_serial(),
+            log.error("Key {0!s} exceeds database field {1:d}!".format(self.get_serial(),
                                                              length))
         self.key_iv = unicode(binascii.hexlify(iv))
         self.count = 0
@@ -290,7 +290,7 @@ class Token(MethodsMixin, db.Model):
         seed_str = self._fix_spaces(self.pin_seed)
         seed = binascii.unhexlify(seed_str)
         hPin = hash(pin, seed)
-        log.debug("hPin: %s, pin: %s, seed: %s" % (binascii.hexlify(hPin),
+        log.debug("hPin: {0!s}, pin: {1!s}, seed: {2!s}".format(binascii.hexlify(hPin),
                                                    pin,
                                                    self.pin_seed))
         return binascii.hexlify(hPin)
@@ -315,10 +315,10 @@ class Token(MethodsMixin, db.Model):
             upin = pin
         if hashed is True:
             self.set_hashed_pin(upin)
-            log.debug("setPin(HASH:%r)" % self.pin_hash)
+            log.debug("setPin(HASH:{0!r})".format(self.pin_hash))
         elif hashed is False:
             self.pin_hash = "@@" + encryptPin(upin)
-            log.debug("setPin(ENCR:%r)" % self.pin_hash)
+            log.debug("setPin(ENCR:{0!r})".format(self.pin_hash))
         return self.pin_hash
 
     def check_pin(self, pin):
@@ -453,10 +453,10 @@ class Token(MethodsMixin, db.Model):
         '''
         ldict = {}
         for attr in self.__dict__:
-            key = "%r" % attr
-            val = "%r" % getattr(self, attr)
+            key = "{0!r}".format(attr)
+            val = "{0!r}".format(getattr(self, attr))
             ldict[key] = val
-        res = "<%r %r>" % (self.__class__, ldict)
+        res = "<{0!r} {1!r}>".format(self.__class__, ldict)
         return res
 
     def set_info(self, info):
@@ -673,7 +673,7 @@ class Config(db.Model):
         self.Description = unicode(Description)
 
     def __unicode__(self):
-        return "<%s (%s)>" % (self.Key, self.Type)
+        return "<{0!s} ({1!s})>".format(self.Key, self.Type)
     
     def save(self):
         db.session.add(self)
@@ -983,7 +983,7 @@ class TokenRealm(MethodsMixin, db.Model):
         :param realm_id: The id of the realm
         :param token_id: The id of the token
         """
-        log.debug("setting realm_id to %i" % realm_id)
+        log.debug("setting realm_id to {0:d}".format(realm_id))
         if realmname:
             r = Realm.query.filter_by(name=realmname).first()
             self.realm_id = r.id
@@ -1158,7 +1158,7 @@ class Challenge(MethodsMixin, db.Model):
         descr['serial'] = self.serial
         descr['data'] = self.get_data()
         if timestamp is True:
-            descr['timestamp'] = "%s" % self.timestamp
+            descr['timestamp'] = "{0!s}".format(self.timestamp)
         else:
             descr['timestamp'] = self.timestamp
         descr['otp_received'] = self.received_count > 0
@@ -1169,7 +1169,7 @@ class Challenge(MethodsMixin, db.Model):
 
     def __unicode__(self):
         descr = self.get()
-        return "%s" % unicode(descr)
+        return "{0!s}".format(unicode(descr))
 
     __str__ = __unicode__
 
@@ -1445,7 +1445,7 @@ class MachineTokenOptions(db.Model):
                                    backref='option_list')
 
     def __init__(self, machinetoken_id, key, value):
-        log.debug("setting %r to %r for MachineToken %s" % (key,
+        log.debug("setting {0!r} to {1!r} for MachineToken {2!s}".format(key,
                                                             value,
                                                             machinetoken_id))
         self.machinetoken_id = machinetoken_id

--- a/privacyidea/webui/certificate.py
+++ b/privacyidea/webui/certificate.py
@@ -79,10 +79,10 @@ def cert_enroll():
     ca = request.form.get("ca")
     # TODO: Read the email address from the user source
     email = "meine"
-    csr = """SPKAC=%s
-CN=%s,CN=%s,O=%s
-emailAddress=%s
-""" % (request_key,
+    csr = """SPKAC={0!s}
+CN={1!s},CN={2!s},O={3!s}
+emailAddress={4!s}
+""".format(request_key,
        request.PI_username,
        request.PI_role,
        request.PI_realm,
@@ -101,7 +101,7 @@ emailAddress=%s
     return render_template("token_enrolled.html",
                            instance=instance,
                            backendUrl=backend_url,
-                           username="%s@%s" % (request.PI_username,
+                           username="{0!s}@{1!s}".format(request.PI_username,
                                                request.PI_realm),
                            role=request.PI_role,
                            serial=serial,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def get_file_contents(file_path):
         full_path = os.path.join(package_directory, file_path)
         content = open(full_path, 'r').read()
     except:
-        print >> sys.stderr, "### could not open file %r" % file_path
+        print >> sys.stderr, "### could not open file {0!r}".format(file_path)
     return content
 
 def get_file_list(file_path):

--- a/tests/base.py
+++ b/tests/base.py
@@ -49,13 +49,13 @@ class MyTestCase(unittest.TestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
 
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
 
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
 
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 
@@ -75,13 +75,13 @@ class MyTestCase(unittest.TestCase):
                     realm=self.realm2,
                     resolver=self.resolvername1)
 
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm2>", user_str)
 
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
 
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm2', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 

--- a/tests/test_api_lib_policy.py
+++ b/tests/test_api_lib_policy.py
@@ -218,7 +218,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Set a policy, that does allow the action
         set_policy(name="pol1",
                    scope=SCOPE.ADMIN,
-                   action="enrollTOTP, enrollHOTP, %s" % ACTION.IMPORT,
+                   action="enrollTOTP, enrollHOTP, {0!s}".format(ACTION.IMPORT),
                    client="10.0.0.0/8")
         g.policy_object = PolicyClass()
 
@@ -254,7 +254,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Set a policy, that allows two tokens per user
         set_policy(name="pol1",
                    scope=SCOPE.ENROLL,
-                   action="%s=%s" % (ACTION.MAXTOKENUSER, 2))
+                   action="{0!s}={1!s}".format(ACTION.MAXTOKENUSER, 2))
         g.policy_object = PolicyClass()
         # The user has one token, everything is fine.
         self.setUp_user_realms()
@@ -334,7 +334,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         self.assertTrue(len(tokenobject_list) == 2)
 
         # request with a user object, not with a realm
-        req.all_data = {"user": "cornelius@%s" % self.realm1}
+        req.all_data = {"user": "cornelius@{0!s}".format(self.realm1)}
 
         # Now a new policy check will fail, since there are already two
         # tokens in the realm
@@ -361,7 +361,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Set a policy, that allows two tokens per realm
         set_policy(name="pol1",
                    scope=SCOPE.AUTHZ,
-                   action="%s=%s" % (ACTION.SETREALM, self.realm1),
+                   action="{0!s}={1!s}".format(ACTION.SETREALM, self.realm1),
                    realm="somerealm")
         g.policy_object = PolicyClass()
 
@@ -381,7 +381,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         #  we get an exception
         set_policy(name="pol2",
                    scope=SCOPE.AUTHZ,
-                   action="%s=%s" % (ACTION.SETREALM, "ConflictRealm"),
+                   action="{0!s}={1!s}".format(ACTION.SETREALM, "ConflictRealm"),
                    realm="somerealm")
         g.policy_object = PolicyClass()
         # This request will trigger two policies with different realms to set
@@ -407,10 +407,10 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Set a policy that defines the tokenlabel
         set_policy(name="pol1",
                    scope=SCOPE.ENROLL,
-                   action="%s=%s" % (ACTION.TOKENLABEL, "<u>@<r>"))
+                   action="{0!s}={1!s}".format(ACTION.TOKENLABEL, "<u>@<r>"))
         set_policy(name="pol2",
                    scope=SCOPE.ENROLL,
-                   action="%s=%s" % (ACTION.TOKENISSUER, "myPI"))
+                   action="{0!s}={1!s}".format(ACTION.TOKENISSUER, "myPI"))
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
@@ -442,11 +442,11 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Set a policy that defines the tokenlabel
         set_policy(name="pol1",
                    scope=SCOPE.ENROLL,
-                   action="%s=%s" % (ACTION.OTPPINRANDOM, "12"))
+                   action="{0!s}={1!s}".format(ACTION.OTPPINRANDOM, "12"))
         set_policy(name="pinhandling",
                    scope=SCOPE.ENROLL,
-                   action="%s=privacyidea.lib.pinhandling.base.PinHandler" %
-                          ACTION.PINHANDLING)
+                   action="{0!s}=privacyidea.lib.pinhandling.base.PinHandler".format(
+                          ACTION.PINHANDLING))
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
@@ -505,7 +505,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Set a policy that defines PIN policy
         set_policy(name="pol1",
                    scope=SCOPE.USER,
-                   action="%s=%s,%s=%s,%s=%s" % (ACTION.OTPPINMAXLEN, "10",
+                   action="{0!s}={1!s},{2!s}={3!s},{4!s}={5!s}".format(ACTION.OTPPINMAXLEN, "10",
                                                  ACTION.OTPPINMINLEN, "4",
                                                  ACTION.OTPPINCONTENTS, "cn"))
         g.policy_object = PolicyClass()
@@ -648,7 +648,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # and only use the last 4 characters of the username
         set_policy(name="mangle1",
                    scope=SCOPE.AUTH,
-                   action="%s=user/.*(.{4}$)/\\1/" % ACTION.MANGLE)
+                   action="{0!s}=user/.*(.{{4}}$)/\\1/".format(ACTION.MANGLE))
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
@@ -660,7 +660,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Set a mangle policy to remove blanks from realm name
         set_policy(name="mangle2",
                    scope=SCOPE.AUTH,
-                   action="%s=realm/\\s//" % ACTION.MANGLE)
+                   action="{0!s}=realm/\\s//".format(ACTION.MANGLE))
         g.policy_object = PolicyClass()
 
         # request, that matches the policy
@@ -689,7 +689,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # A user, for whom the login via REMOTE_USER is allowed.
         set_policy(name="ruser",
                    scope=SCOPE.WEBUI,
-                   action="%s=%s" % (ACTION.REMOTE_USER, REMOTE_USER.ACTIVE))
+                   action="{0!s}={1!s}".format(ACTION.REMOTE_USER, REMOTE_USER.ACTIVE))
         g.policy_object = PolicyClass()
 
         r = is_remote_user_allowed(req)
@@ -699,7 +699,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # Only allowed for user "super", but REMOTE_USER=admin
         set_policy(name="ruser",
                    scope=SCOPE.WEBUI,
-                   action="%s=%s" % (ACTION.REMOTE_USER, REMOTE_USER.ACTIVE),
+                   action="{0!s}={1!s}".format(ACTION.REMOTE_USER, REMOTE_USER.ACTIVE),
                    user="super")
         g.policy_object = PolicyClass()
 
@@ -723,7 +723,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # and only use the last 4 characters of the username
         set_policy(name="email1",
                    scope=SCOPE.REGISTER,
-                   action="%s=/.*@mydomain\..*" % ACTION.REQUIREDEMAIL)
+                   action="{0!s}=/.*@mydomain\..*".format(ACTION.REQUIREDEMAIL))
         g.policy_object = PolicyClass()
         # request, that matches the policy
         req.all_data = {"email": "user@mydomain.net"}
@@ -758,7 +758,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # and only use the last 4 characters of the username
         set_policy(name="recover",
                    scope=SCOPE.USER,
-                   action="%s" % ACTION.RESYNC)
+                   action="{0!s}".format(ACTION.RESYNC))
         g.policy_object = PolicyClass()
         req.all_data = {"user": "cornelius", "realm": self.realm1}
         # There is a user policy without password reset, so an exception is
@@ -769,7 +769,7 @@ class PrePolicyDecoratorTestCase(MyTestCase):
         # The password reset is allowed
         set_policy(name="recover",
                    scope=SCOPE.USER,
-                   action="%s" % ACTION.PASSWORDRESET)
+                   action="{0!s}".format(ACTION.PASSWORDRESET))
         g.policy_object = PolicyClass()
         r = check_anonymous_user(req, ACTION.PASSWORDRESET)
         self.assertEqual(r, True)
@@ -985,7 +985,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
         # to "any_pin"
         set_policy(name="pol2",
                    scope=SCOPE.ENROLL,
-                   action="%s=%s" % (ACTION.AUTOASSIGN, AUTOASSIGNVALUE.NONE),
+                   action="{0!s}={1!s}".format(ACTION.AUTOASSIGN, AUTOASSIGNVALUE.NONE),
                                      client="10.0.0.0/8")
         g.policy_object = PolicyClass()
 
@@ -1043,7 +1043,7 @@ class PostPolicyDecoratorTestCase(MyTestCase):
         # to "userstore"
         set_policy(name="pol2",
                    scope=SCOPE.ENROLL,
-                   action="%s=%s" % (ACTION.AUTOASSIGN,
+                   action="{0!s}={1!s}".format(ACTION.AUTOASSIGN,
                                      AUTOASSIGNVALUE.USERSTORE),
                                      client="10.0.0.0/8")
         g.policy_object = PolicyClass()

--- a/tests/test_api_machines.py
+++ b/tests/test_api_machines.py
@@ -247,7 +247,7 @@ class APIMachinesTestCase(MyTestCase):
         # Remove everything that sounds like "SOMETHING\" in front of
         # the username
         set_policy(name="mangle1", scope=SCOPE.AUTH,
-                   action="%s=user/.*\\\\(.*)/\\1/" % ACTION.MANGLE)
+                   action="{0!s}=user/.*\\\\(.*)/\\1/".format(ACTION.MANGLE))
         with self.app.test_request_context(
                 '/machine/authitem/ssh?hostname=gandalf&user=DOMAIN\\testuser',
                 method='GET',

--- a/tests/test_api_register.py
+++ b/tests/test_api_register.py
@@ -59,7 +59,7 @@ class RegisterTestCase(MyTestCase):
 
         # create policy
         r = set_policy(name="pol2", scope=SCOPE.REGISTER,
-                       action="%s=%s, %s=%s" % (ACTION.REALM, "register",
+                       action="{0!s}={1!s}, {2!s}={3!s}".format(ACTION.REALM, "register",
                                                 ACTION.RESOLVER, "register"))
 
         # Try to register, but missing parameter
@@ -88,7 +88,7 @@ class RegisterTestCase(MyTestCase):
         # Set SMTP config and policy
         add_smtpserver("myserver", "1.2.3.4", sender="pi@localhost")
         set_policy("pol3", scope=SCOPE.REGISTER,
-                   action="%s=myserver" % ACTION.EMAILCONFIG)
+                   action="{0!s}=myserver".format(ACTION.EMAILCONFIG))
         with self.app.test_request_context('/register',
                                            method='POST',
                                            data={"username": "corneliusReg",

--- a/tests/test_api_roles.py
+++ b/tests/test_api_roles.py
@@ -61,8 +61,8 @@ class APIAuthTestCase(MyTestCase):
 
     def test_02_REMOTE_USER(self):
         # Allow remote user
-        set_policy(name="remote", scope=SCOPE.WEBUI, action="%s=allowed" %
-                                                            ACTION.REMOTE_USER)
+        set_policy(name="remote", scope=SCOPE.WEBUI, action="{0!s}=allowed".format(
+                                                            ACTION.REMOTE_USER))
 
         # Admin remote user
         with self.app.test_request_context('/auth', method='POST',
@@ -307,7 +307,7 @@ class APISelfserviceTestCase(MyTestCase):
                         tokenobject.token.resolver == "resolver1")
 
         # user can delete his own token
-        with self.app.test_request_context('/token/%s' % serial,
+        with self.app.test_request_context('/token/{0!s}'.format(serial),
                                            method='DELETE',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -323,7 +323,7 @@ class APISelfserviceTestCase(MyTestCase):
     def test_04_user_can_not_delete_another_token(self):
         self.authenticate_selfserive_user()
         assign_token(self.foreign_serial, User("cornelius", self.realm1))
-        with self.app.test_request_context('/token/%s' % self.foreign_serial,
+        with self.app.test_request_context('/token/{0!s}'.format(self.foreign_serial),
                                            method='DELETE',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -339,8 +339,8 @@ class APISelfserviceTestCase(MyTestCase):
     def test_04_user_can_not_disable_another_token(self):
         self.authenticate_selfserive_user()
         assign_token(self.foreign_serial, User("cornelius", self.realm1))
-        with self.app.test_request_context('/token/disable/%s' %
-                                                   self.foreign_serial,
+        with self.app.test_request_context('/token/disable/{0!s}'.format(
+                                                   self.foreign_serial),
                                            method='POST',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -357,8 +357,8 @@ class APISelfserviceTestCase(MyTestCase):
     def test_04_user_can_not_lost_another_token(self):
         self.authenticate_selfserive_user()
         assign_token(self.foreign_serial, User("cornelius", self.realm1))
-        with self.app.test_request_context('/token/lost/%s' %
-                                                   self.foreign_serial,
+        with self.app.test_request_context('/token/lost/{0!s}'.format(
+                                                   self.foreign_serial),
                                            method='POST',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -369,8 +369,8 @@ class APISelfserviceTestCase(MyTestCase):
     def test_05_user_can_disable_token(self):
         self.authenticate_selfserive_user()
         # User can not disable a token, that does not belong to him.
-        with self.app.test_request_context('/token/disable/%s' %
-                                                   self.foreign_serial,
+        with self.app.test_request_context('/token/disable/{0!s}'.format(
+                                                   self.foreign_serial),
                                            method='POST',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -383,7 +383,7 @@ class APISelfserviceTestCase(MyTestCase):
         self.assertTrue(tokenobject.token.active, tokenobject.token.active)
 
         # User disables his token
-        with self.app.test_request_context('/token/disable/%s' % self.my_serial,
+        with self.app.test_request_context('/token/disable/{0!s}'.format(self.my_serial),
                                            method='POST',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -397,7 +397,7 @@ class APISelfserviceTestCase(MyTestCase):
         self.assertFalse(tokenobject.token.active, tokenobject.token.active)
 
         # User enables his token
-        with self.app.test_request_context('/token/enable/%s' % self.my_serial,
+        with self.app.test_request_context('/token/enable/{0!s}'.format(self.my_serial),
                                            method='POST',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -415,8 +415,8 @@ class APISelfserviceTestCase(MyTestCase):
         # Is token disabled?
         tokenobject = get_tokens(serial=self.foreign_serial)[0]
         self.assertFalse(tokenobject.token.active, tokenobject.token.active)
-        with self.app.test_request_context('/token/enable/%s' %
-                                                   self.foreign_serial,
+        with self.app.test_request_context('/token/enable/{0!s}'.format(
+                                                   self.foreign_serial),
                                            method='POST',
                                            headers={'Authorization':
                                                         self.at_user}):
@@ -560,7 +560,7 @@ class APISelfserviceTestCase(MyTestCase):
             self.assertTrue(res.status_code == 401, res)
 
         # Can not set token realm
-        with self.app.test_request_context('/token/realm/%s' % serial,
+        with self.app.test_request_context('/token/realm/{0!s}'.format(serial),
                                             method="POST",
                                             data={"realms": "realm1"},
                                             headers={'Authorization':
@@ -601,11 +601,11 @@ class APISelfserviceTestCase(MyTestCase):
             self.assertTrue(res.status_code == 401, res)
 
     def test_41_webui_settings(self):
-        set_policy(name="webui1", scope=SCOPE.WEBUI, action="%s=%s" % (
+        set_policy(name="webui1", scope=SCOPE.WEBUI, action="{0!s}={1!s}".format(
             ACTION.TOKENPAGESIZE, 20))
-        set_policy(name="webui2", scope=SCOPE.WEBUI, action="%s=%s" % (
+        set_policy(name="webui2", scope=SCOPE.WEBUI, action="{0!s}={1!s}".format(
             ACTION.USERPAGESIZE, 20))
-        set_policy(name="webui3", scope=SCOPE.WEBUI, action="%s=%s" % (
+        set_policy(name="webui3", scope=SCOPE.WEBUI, action="{0!s}={1!s}".format(
             ACTION.LOGOUTTIME, 200))
         with self.app.test_request_context('/auth',
                                            method='POST',

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -379,7 +379,7 @@ class APIConfigTestCase(MyTestCase):
         resolvername = "reso1_with_realm"
         realmname = "realm1_with_resolver"
         # create a resolver
-        with self.app.test_request_context('/resolver/%s' % resolvername,
+        with self.app.test_request_context('/resolver/{0!s}'.format(resolvername),
                                            method='POST',
                                            data={"filename": PWFILE,
                                                  "type": "passwdresolver"},
@@ -392,7 +392,7 @@ class APIConfigTestCase(MyTestCase):
             self.assertTrue(result["value"] > 0, result)
 
         # create a realm
-        with self.app.test_request_context('/realm/%s' % realmname,
+        with self.app.test_request_context('/realm/{0!s}'.format(realmname),
                                            method='POST',
                                            data={"resolvers": resolvername},
                                            headers={'Authorization': self.at}):
@@ -429,7 +429,7 @@ class APIConfigTestCase(MyTestCase):
             self.assertTrue("adminrealm" in result["value"], result)
 
         # try to delete the resolver in the realm
-        with self.app.test_request_context('/resolver/%s' % resolvername,
+        with self.app.test_request_context('/resolver/{0!s}'.format(resolvername),
                                             method='DELETE',
                                             headers={'Authorization': self.at}):
             # The resolver must not be deleted, since it is contained in a realm
@@ -437,7 +437,7 @@ class APIConfigTestCase(MyTestCase):
             self.assertTrue(res.status_code == 400, res)
 
         # delete the realm
-        with self.app.test_request_context('/realm/%s' % realmname,
+        with self.app.test_request_context('/realm/{0!s}'.format(realmname),
                                             method='DELETE',
                                             headers={'Authorization': self.at}):
             # The realm gets deleted
@@ -449,7 +449,7 @@ class APIConfigTestCase(MyTestCase):
             self.assertTrue(result["value"] == 1, result)
 
         # Now, we can delete the resolver
-        with self.app.test_request_context('/resolver/%s' % resolvername,
+        with self.app.test_request_context('/resolver/{0!s}'.format(resolvername),
                                             method='DELETE',
                                             headers={'Authorization': self.at}):
             # The resolver must not be deleted, since it is contained in a realm
@@ -465,7 +465,7 @@ class APIConfigTestCase(MyTestCase):
     def test_10_default_realm(self):
         resolvername = "defresolver"
         realmname = "defrealm"
-        with self.app.test_request_context('/resolver/%s' % resolvername,
+        with self.app.test_request_context('/resolver/{0!s}'.format(resolvername),
                                            method='POST',
                                            data={"filename": PWFILE,
                                                  "type": "passwdresolver"},
@@ -476,7 +476,7 @@ class APIConfigTestCase(MyTestCase):
             self.assertTrue(result["status"] is True, result)
 
         # create a realm
-        with self.app.test_request_context('/realm/%s' % realmname,
+        with self.app.test_request_context('/realm/{0!s}'.format(realmname),
                                            method='POST',
                                            data={"resolvers": resolvername,
                                                  "priority.defresolver": 10},

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -159,7 +159,7 @@ class APITokenTestCase(MyTestCase):
             detail = json.loads(res.data).get("detail")
             tokenlist = result.get("value").get("tokens")
             # NO token assigned, yet
-            self.assertTrue(len(tokenlist) == 0, "%s" % tokenlist)
+            self.assertTrue(len(tokenlist) == 0, "{0!s}".format(tokenlist))
 
         # get unassigned tokens
         with self.app.test_request_context('/token/',
@@ -921,8 +921,8 @@ class APITokenTestCase(MyTestCase):
         for timestep in ["30", "60"]:
             with self.app.test_request_context('/token/init',
                                                data={"type": "totp",
-                                                     "serial": "totp%s" %
-                                                             timestep,
+                                                     "serial": "totp{0!s}".format(
+                                                             timestep),
                                                      "timeStep": timestep,
                                                      "genkey": "1"},
                                                method="POST",
@@ -933,7 +933,7 @@ class APITokenTestCase(MyTestCase):
                 self.assertTrue(result.get("value"))
                 detail = json.loads(res.data).get("detail")
 
-            token = get_tokens(serial="totp%s" % timestep)[0]
+            token = get_tokens(serial="totp{0!s}".format(timestep))[0]
             self.assertEqual(token.timestep, int(timestep))
 
     def test_17_enroll_certificate(self):
@@ -985,7 +985,7 @@ class APITokenTestCase(MyTestCase):
 
     def test_19_get_challenges(self):
         set_policy("chalresp", scope=SCOPE.AUTHZ,
-        action="%s=hotp" % ACTION.CHALLENGERESPONSE)
+        action="{0!s}=hotp".format(ACTION.CHALLENGERESPONSE))
         token = init_token({"genkey": 1, "serial": "CHAL1", "pin": "pin"})
         serial = token.token.serial
         r = check_serial_pass(serial, "pin")

--- a/tests/test_api_u2f.py
+++ b/tests/test_api_u2f.py
@@ -155,7 +155,7 @@ class APIU2fTestCase(MyTestCase):
             self.assertTrue("trustedFacets" in data)
 
         set_policy(name="facet1", scope=SCOPE.AUTH,
-                   action="%s=host1 host2 host3" % U2FACTION.FACETS)
+                   action="{0!s}=host1 host2 host3".format(U2FACTION.FACETS))
 
         with self.app.test_request_context('/ttype/u2f',
                                            method='GET'):

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -49,7 +49,7 @@ class APIUsersTestCase(MyTestCase):
         # create realm
         realm = u"realm1"
         resolvers = u"r1, r2"
-        with self.app.test_request_context('/realm/%s' % realm,
+        with self.app.test_request_context('/realm/{0!s}'.format(realm),
                                            data={u"resolvers": resolvers},
                                            method='POST',
                                            headers={"Authorization": self.at}):
@@ -158,7 +158,7 @@ class APIUsersTestCase(MyTestCase):
         # Get user authentication and update by user.
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username": "wordy@%s" % realm,
+                                           data={"username": "wordy@{0!s}".format(realm),
                                                  "password": "passwort"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -189,7 +189,7 @@ class APIUsersTestCase(MyTestCase):
         # "wordy2", he updated his own password.
         with self.app.test_request_context('/auth',
                                            method='POST',
-                                           data={"username": "wordy@%s" % realm,
+                                           data={"username": "wordy@{0!s}".format(realm),
                                                  "password": "newPassword"}):
             res = self.app.full_dispatch_request()
             self.assertTrue(res.status_code == 200, res)
@@ -202,7 +202,7 @@ class APIUsersTestCase(MyTestCase):
             self.assertTrue(role == "user", result)
 
         # Delete the users
-        with self.app.test_request_context('/user/%s/%s' % (resolver, "wordy"),
+        with self.app.test_request_context('/user/{0!s}/{1!s}'.format(resolver, "wordy"),
                                            method='DELETE',
                                            headers={'Authorization': self.at}):
             res = self.app.full_dispatch_request()

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -716,7 +716,7 @@ class ValidateAPITestCase(MyTestCase):
         # set policy for timelimit
         set_policy(name="pol_time1",
                    scope=SCOPE.AUTHZ,
-                   action="%s=2/20s" % ACTION.AUTHMAXSUCCESS)
+                   action="{0!s}=2/20s".format(ACTION.AUTHMAXSUCCESS))
 
         for i in [1, 2]:
             with self.app.test_request_context('/validate/check',
@@ -751,7 +751,7 @@ class ValidateAPITestCase(MyTestCase):
         # set policy for timelimit
         set_policy(name="pol_time1",
                    scope=SCOPE.AUTHZ,
-                   action="%s=2/20s" % ACTION.AUTHMAXFAIL)
+                   action="{0!s}=2/20s".format(ACTION.AUTHMAXFAIL))
 
         for i in [1, 2]:
             with self.app.test_request_context('/validate/check',
@@ -877,7 +877,7 @@ class ValidateAPITestCase(MyTestCase):
         # user disableduser, realm: self.realm2, passwd: superSecret
         set_policy(name="disabled",
                    scope=SCOPE.AUTH,
-                   action="%s=%s" % (ACTION.OTPPIN, "userstore"))
+                   action="{0!s}={1!s}".format(ACTION.OTPPIN, "userstore"))
         # enroll two tokens
         r = init_token({"type": "spass", "serial": "spass1d"},
                        user=User("disableduser", self.realm2))
@@ -923,7 +923,7 @@ class ValidateAPITestCase(MyTestCase):
         user = "lockeduser"
         set_policy(name="locked",
                    scope=SCOPE.AUTH,
-                   action="%s=%s" % (ACTION.OTPPIN, "tokenpin"))
+                   action="{0!s}={1!s}".format(ACTION.OTPPIN, "tokenpin"))
         r = init_token({"type": "spass", "serial": "spass1l",
                         "pin": "locked"},
                        user=User(user, self.realm2))

--- a/tests/test_db_model.py
+++ b/tests/test_db_model.py
@@ -169,7 +169,7 @@ class TokenModelTestCase(MyTestCase):
         self.assertTrue(t3.get_info().get("info") == "value")
         
         # test the string represenative
-        s = "%s" % t3
+        s = "{0!s}".format(t3)
         self.assertTrue(s == "serial2")
         
         # update token type
@@ -198,7 +198,7 @@ class TokenModelTestCase(MyTestCase):
         
         cid = c.save()
         self.assertTrue(cid == "splitRealm", cid)
-        self.assertTrue(u"%s" % c == "<splitRealm (string)>", c)
+        self.assertTrue(u"{0!s}".format(c) == "<splitRealm (string)>", c)
         
         # delete the config
         config = Config.query.filter_by(Key="splitRealm").first()
@@ -366,9 +366,9 @@ class TokenModelTestCase(MyTestCase):
         c.set_challenge("challenge")
         self.assertTrue(c.get_challenge() == "challenge", c.challenge)
         
-        self.assertTrue("otp_received" in "%s" % c, "%s" % c)
-        self.assertTrue("transaction_id" in "%s" % c, "%s" % c)
-        self.assertTrue("timestamp" in "%s" % c, "%s" % c)
+        self.assertTrue("otp_received" in "{0!s}".format(c), "{0!s}".format(c))
+        self.assertTrue("transaction_id" in "{0!s}".format(c), "{0!s}".format(c))
+        self.assertTrue("timestamp" in "{0!s}".format(c), "{0!s}".format(c))
         
         # test with timestamp=True, which results in something like this:
         timestamp = '2014-11-29 21:56:43.057293'

--- a/tests/test_lib_audit.py
+++ b/tests/test_lib_audit.py
@@ -77,7 +77,7 @@ class AuditTestCase(MyTestCase):
         # with search filter
         tot = self.Audit.get_total({"action": "action2",
                                     "bullshit": "value"})
-        self.assertTrue(tot == 2, "Total numbers: %s" % tot)
+        self.assertTrue(tot == 2, "Total numbers: {0!s}".format(tot))
 
     def test_02_filter_search(self):
         # Prepare some audit entries:

--- a/tests/test_lib_caconnector.py
+++ b/tests/test_lib_caconnector.py
@@ -173,10 +173,10 @@ class LocalCATestCase(MyTestCase):
                                   {"CSRDir": "",
                                    "CertificateDir": "",
                                    "WorkingDir": cwd + "/" + WORKINGDIR})
-        self.assertEqual("%r" % cert.get_issuer(),
+        self.assertEqual("{0!r}".format(cert.get_issuer()),
                          "<X509Name object "
                          "'/C=DE/ST=Hessen/O=privacyidea/CN=CA001'>")
-        self.assertEqual("%r" % cert.get_subject(),
+        self.assertEqual("{0!r}".format(cert.get_subject()),
                          "<X509Name object "
                          "'/C=DE/ST=Hessen/O=privacyidea/CN=requester"
                          ".localdomain'>")
@@ -191,10 +191,10 @@ class LocalCATestCase(MyTestCase):
                                   "WorkingDir": cwd + "/" + WORKINGDIR})
 
         cert = cacon.sign_request(REQUEST_USER)
-        self.assertEqual("%r" % cert.get_issuer(),
+        self.assertEqual("{0!r}".format(cert.get_issuer()),
                          "<X509Name object "
                          "'/C=DE/ST=Hessen/O=privacyidea/CN=CA001'>")
-        self.assertEqual("%r" % cert.get_subject(),
+        self.assertEqual("{0!r}".format(cert.get_subject()),
                          "<X509Name object "
                          "'/C=DE/ST=Hessen/O=privacyidea/CN=usercert'>")
 
@@ -207,10 +207,10 @@ class LocalCATestCase(MyTestCase):
                                   "WorkingDir": cwd + "/" + WORKINGDIR})
 
         cert = cacon.sign_request(SPKAC, options={"spkac": 1})
-        self.assertEqual("%r" % cert.get_issuer(),
+        self.assertEqual("{0!r}".format(cert.get_issuer()),
                          "<X509Name object "
                          "'/C=DE/ST=Hessen/O=privacyidea/CN=CA001'>")
-        self.assertEqual("%r" % cert.get_subject(),
+        self.assertEqual("{0!r}".format(cert.get_subject()),
                          "<X509Name object '/CN=Steve Test"
                          "/emailAddress=steve@openssl.org'>")
 

--- a/tests/test_lib_challenges.py
+++ b/tests/test_lib_challenges.py
@@ -19,7 +19,7 @@ class ChallengeTestCase(MyTestCase):
     def test_01_challenge(self):
 
         set_policy("chalresp", scope=SCOPE.AUTHZ,
-                   action="%s=hotp" % ACTION.CHALLENGERESPONSE)
+                   action="{0!s}=hotp".format(ACTION.CHALLENGERESPONSE))
         token = init_token({"genkey": 1, "serial": "CHAL1", "pin": "pin"})
         from privacyidea.lib.token import check_serial_pass
         r = check_serial_pass(token.token.serial, "pin")

--- a/tests/test_lib_policy.py
+++ b/tests/test_lib_policy.py
@@ -135,7 +135,7 @@ class PolicyTestCase(MyTestCase):
         self.assertTrue(len(policies) == 2, policies)
         # find policies with user admin
         policies = P.get_policies(scope="admin", user="admin")
-        self.assertTrue(len(policies) == 1, "%s" % len(policies))
+        self.assertTrue(len(policies) == 1, "{0!s}".format(len(policies)))
         # find policies with resolver2 and authorization. THe result should
         # be pol2 and pol2a
         policies = P.get_policies(resolver="resolver2", scope=SCOPE.AUTHZ)

--- a/tests/test_lib_policydecorator.py
+++ b/tests/test_lib_policydecorator.py
@@ -55,7 +55,7 @@ class LibPolicyTestCase(MyTestCase):
         my_user = User("cornelius", realm="r1")
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
-                   action="%s=%s" % (ACTION.OTPPIN, ACTIONVALUE.NONE))
+                   action="{0!s}={1!s}".format(ACTION.OTPPIN, ACTIONVALUE.NONE))
         g = FakeFlaskG()
         P = PolicyClass()
         g.policy_object = P
@@ -80,7 +80,7 @@ class LibPolicyTestCase(MyTestCase):
         delete_policy("pol1")
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
-                   action="%s=%s" % (ACTION.OTPPIN, ACTIONVALUE.TOKENPIN))
+                   action="{0!s}={1!s}".format(ACTION.OTPPIN, ACTIONVALUE.TOKENPIN))
         g = FakeFlaskG()
         P = PolicyClass()
         g.policy_object = P
@@ -110,7 +110,7 @@ class LibPolicyTestCase(MyTestCase):
         # now create a policy with userstore PW
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
-                   action="%s=%s" % (ACTION.OTPPIN, ACTIONVALUE.USERSTORE))
+                   action="{0!s}={1!s}".format(ACTION.OTPPIN, ACTIONVALUE.USERSTORE))
         g = FakeFlaskG()
         P = PolicyClass()
         g.policy_object = P
@@ -133,7 +133,7 @@ class LibPolicyTestCase(MyTestCase):
         # now create a policy with userstore PW
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
-                   action="%s=%s" % (ACTION.OTPPIN, ACTIONVALUE.USERSTORE))
+                   action="{0!s}={1!s}".format(ACTION.OTPPIN, ACTIONVALUE.USERSTORE))
         g = FakeFlaskG()
         P = PolicyClass()
         g.policy_object = P
@@ -239,7 +239,7 @@ class LibPolicyTestCase(MyTestCase):
         # Now set a PASSTHRU policy to the userstore (new style)
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
-                   action="%s=userstore" % ACTION.PASSTHRU)
+                   action="{0!s}=userstore".format(ACTION.PASSTHRU))
         g = FakeFlaskG()
         g.policy_object = PolicyClass()
         options = {"g": g}
@@ -254,7 +254,7 @@ class LibPolicyTestCase(MyTestCase):
         radiusmock.setdata(success=True)
         set_policy(name="pol1",
                    scope=SCOPE.AUTH,
-                   action="%s=radiusconfig1" % ACTION.PASSTHRU)
+                   action="{0!s}=radiusconfig1".format(ACTION.PASSTHRU))
         r = add_radius("radiusconfig1", "1.2.3.4", "testing123",
                        dictionary=DICT_FILE)
         self.assertTrue(r > 0)
@@ -308,7 +308,7 @@ class LibPolicyTestCase(MyTestCase):
 
         set_policy(name="pol2",
                    scope=SCOPE.WEBUI,
-                   action="%s=%s" % (ACTION.LOGINMODE, LOGINMODE.PRIVACYIDEA))
+                   action="{0!s}={1!s}".format(ACTION.LOGINMODE, LOGINMODE.PRIVACYIDEA))
         g = FakeFlaskG()
         P = PolicyClass()
         g.policy_object = P
@@ -321,7 +321,7 @@ class LibPolicyTestCase(MyTestCase):
         # Set policy, so that the user is not allowed to login at all
         set_policy(name="pol2",
                    scope=SCOPE.WEBUI,
-                   action="%s=%s" % (ACTION.LOGINMODE, LOGINMODE.DISABLE))
+                   action="{0!s}={1!s}".format(ACTION.LOGINMODE, LOGINMODE.DISABLE))
         g = FakeFlaskG()
         P = PolicyClass()
         g.policy_object = P
@@ -390,10 +390,10 @@ class LibPolicyTestCase(MyTestCase):
         # Now we set a policy with several tokentypes
         set_policy(name="pol_chal_resp_1",
                    scope=SCOPE.AUTH,
-                   action="%s=hotp tiqr totp" % ACTION.CHALLENGERESPONSE)
+                   action="{0!s}=hotp tiqr totp".format(ACTION.CHALLENGERESPONSE))
         set_policy(name="pol_chal_resp_2",
                    scope=SCOPE.AUTH,
-                   action="%s=hotp motp" % ACTION.CHALLENGERESPONSE)
+                   action="{0!s}=hotp motp".format(ACTION.CHALLENGERESPONSE))
         g = FakeFlaskG()
         g.policy_object = PolicyClass()
         options = {"g": g}
@@ -419,7 +419,7 @@ class LibPolicyTestCase(MyTestCase):
         # set time limit policy
         set_policy(name="pol_lastauth",
                    scope=SCOPE.AUTHZ,
-                   action="%s=1d" % ACTION.LASTAUTH)
+                   action="{0!s}=1d".format(ACTION.LASTAUTH))
         g = FakeFlaskG()
         g.policy_object = PolicyClass()
         options = {"g": g}

--- a/tests/test_lib_resolver.py
+++ b/tests/test_lib_resolver.py
@@ -638,7 +638,7 @@ class LDAPResolverTestCase(MyTestCase):
 
         user = "bob"
         user_id = y.getUserId(user)
-        self.assertTrue(user_id == "3", "%s" % user_id)
+        self.assertTrue(user_id == "3", "{0!s}".format(user_id))
 
         rid = y.getResolverId()
         self.assertTrue(rid == "ldap://localhost", rid)
@@ -1141,7 +1141,7 @@ class ResolverTestCase(MyTestCase):
         r = y.getUserList({"userid": "between 1001, 1000"})
         self.assertTrue(len(r) == 2, r)
         r = y.getUserList({"userid": "<=1000"})
-        self.assertTrue(len(r) == 1, "%s" % r)
+        self.assertTrue(len(r) == 1, "{0!s}".format(r))
         r = y.getUserList({"userid": ">=1000"})
         self.assertTrue(len(r) > 1, r)
 

--- a/tests/test_lib_smsprovider.py
+++ b/tests/test_lib_smsprovider.py
@@ -22,11 +22,11 @@ class SMSTestCase(MyTestCase):
 
     def test_00_SMSError(self):
         err = SMSError(100, "Some Error")
-        text = "%r" % err
+        text = "{0!r}".format(err)
         self.assertTrue(text == "SMSError(error_id=100, description='Some "
                                 "Error')", text)
 
-        text = "%s" % err
+        text = "{0!s}".format(err)
         self.assertTrue(text == "Some Error", text)
 
     def test_01_get_provider_class(self):

--- a/tests/test_lib_token.py
+++ b/tests/test_lib_token.py
@@ -180,7 +180,7 @@ class TokenTestCase(MyTestCase):
     def test_05_get_num_tokens_in_realm(self):
         # one active token
         self.assertTrue(get_num_tokens_in_realm(self.realm1) == 1,
-                        "%r" % get_num_tokens_in_realm(self.realm1))
+                        "{0!r}".format(get_num_tokens_in_realm(self.realm1)))
         # No active tokens
         self.assertTrue(get_num_tokens_in_realm(self.realm1, active=False) == 0)
 
@@ -191,7 +191,7 @@ class TokenTestCase(MyTestCase):
     def test_06_get_realms_of_token(self):
         # Return a list of realmnames for a token
         self.assertTrue(get_realms_of_token("hotptoken") == [self.realm1],
-                        "%s" % get_realms_of_token("hotptoken"))
+                        "{0!s}".format(get_realms_of_token("hotptoken")))
 
     def test_07_token_exist(self):
         self.assertTrue(token_exist("hotptoken"))
@@ -383,14 +383,14 @@ class TokenTestCase(MyTestCase):
         tokenobject = init_token({"serial": serial,
                                   "otpkey": "1234567890123456"})
         realms = get_realms_of_token(serial)
-        self.assertTrue(realms == [], "%s" % realms)
+        self.assertTrue(realms == [], "{0!s}".format(realms))
         rnum = set_realms(serial, [self.realm1])
         self.assertTrue(rnum == 1, rnum)
         realms = get_realms_of_token(serial)
-        self.assertTrue(realms == [self.realm1], "%s" % realms)
+        self.assertTrue(realms == [self.realm1], "{0!s}".format(realms))
         remove_token(serial=serial)
         realms = get_realms_of_token(serial)
-        self.assertTrue(realms == [], "%s" % realms)
+        self.assertTrue(realms == [], "{0!s}".format(realms))
 
 
     def test_17_set_defaults(self):
@@ -588,7 +588,7 @@ class TokenTestCase(MyTestCase):
         r = set_max_failcount(serial, 112)
         self.assertTrue(r == 1, r)
         self.assertTrue(tokenobject.token.maxfail == 112,
-                        "%s" % tokenobject.token.maxfail)
+                        "{0!s}".format(tokenobject.token.maxfail))
         remove_token(serial)
 
     def test_31_copy_token_pin(self):
@@ -603,7 +603,7 @@ class TokenTestCase(MyTestCase):
 
         # Now compare the pinhash
         self.assertTrue(tobject1.token.pin_hash == tobject2.token.pin_hash,
-                        "%s <> %s" % (tobject1.token.pin_hash,
+                        "{0!s} <> {1!s}".format(tobject1.token.pin_hash,
                                       tobject2.token.pin_hash))
 
         remove_token(serial1)
@@ -654,7 +654,7 @@ class TokenTestCase(MyTestCase):
         self.assertTrue(r.get("pin") == True, r)
         self.assertTrue(r.get("init") == True, r)
         self.assertTrue(r.get("user") == True, r)
-        self.assertTrue(r.get("serial") == "lost%s" % serial1, r)
+        self.assertTrue(r.get("serial") == "lost{0!s}".format(serial1), r)
         remove_token("losttoken")
         remove_token("lostlosttoken")
 
@@ -772,7 +772,7 @@ class TokenTestCase(MyTestCase):
         r, reply = check_user_pass(user, "passwordasdf")
         self.assertFalse(r)
         self.assertTrue(reply.get("message") == 'The user has no tokens '
-                                                'assigned', "%s" % reply)
+                                                'assigned', "{0!s}".format(reply))
 
         user = User("cornelius", realm=self.realm1)
         r, reply = check_user_pass(user, "hotppin868912")

--- a/tests/test_lib_tokenclass.py
+++ b/tests/test_lib_tokenclass.py
@@ -45,13 +45,13 @@ class TokenBaseTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
         
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
         
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
         
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 
@@ -73,7 +73,7 @@ class TokenBaseTestCase(MyTestCase):
         token.save()
 
         info = token.get_class_info()
-        self.assertTrue(info == {}, "%s" % info)
+        self.assertTrue(info == {}, "{0!s}".format(info))
         
     def test_02_set_user(self):
         db_token = Token.query.filter_by(serial=self.serial1).first()

--- a/tests/test_lib_tokens_certificate.py
+++ b/tests/test_lib_tokens_certificate.py
@@ -124,10 +124,10 @@ class CertificateTokenTestCase(MyTestCase):
         certificate = detail.get("certificate")
         # At each testrun, the certificate might get another serial number!
         x509obj = crypto.load_certificate(crypto.FILETYPE_PEM, certificate)
-        self.assertEqual("%r" % x509obj.get_issuer(),
+        self.assertEqual("{0!r}".format(x509obj.get_issuer()),
                          "<X509Name object '/C=DE/ST=Hessen"
                          "/O=privacyidea/CN=CA001'>")
-        self.assertEqual("%r" % x509obj.get_subject(),
+        self.assertEqual("{0!r}".format(x509obj.get_subject()),
                          "<X509Name object '/C=DE/ST=Hessen"
                          "/O=privacyidea/CN=requester.localdomain'>")
 
@@ -136,10 +136,10 @@ class CertificateTokenTestCase(MyTestCase):
         token = get_tokens(serial=self.serial2)[0]
         certificate = token.get_tokeninfo("certificate")
         x509obj = crypto.load_certificate(crypto.FILETYPE_PEM, certificate)
-        self.assertEqual("%r" % x509obj.get_issuer(),
+        self.assertEqual("{0!r}".format(x509obj.get_issuer()),
                          "<X509Name object '/C=DE/ST=Hessen"
                          "/O=privacyidea/CN=CA001'>")
-        self.assertEqual("%r" % x509obj.get_subject(),
+        self.assertEqual("{0!r}".format(x509obj.get_subject()),
                          "<X509Name object '/C=DE/ST=Hessen"
                          "/O=privacyidea/CN=requester.localdomain'>")
 

--- a/tests/test_lib_tokens_daplug.py
+++ b/tests/test_lib_tokens_daplug.py
@@ -47,13 +47,13 @@ class DaplugTokenTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
 
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
 
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
 
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 

--- a/tests/test_lib_tokens_email.py
+++ b/tests/test_lib_tokens_email.py
@@ -47,13 +47,13 @@ class EmailTokenTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
 
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
 
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
 
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 
@@ -335,7 +335,7 @@ class EmailTokenTestCase(MyTestCase):
     def test_19_emailtext(self):
         # create a EMAILTEXT policy:
         p = set_policy(name="emailtext",
-                       action="%s=%s" % (EMAILACTION.EMAILTEXT, "'Your <otp>'"),
+                       action="{0!s}={1!s}".format(EMAILACTION.EMAILTEXT, "'Your <otp>'"),
                        scope=SCOPE.AUTH)
         self.assertTrue(p > 0)
 

--- a/tests/test_lib_tokens_foureyes.py
+++ b/tests/test_lib_tokens_foureyes.py
@@ -53,7 +53,7 @@ class FourEyesTokenTestCase(MyTestCase):
 
         init_token({"serial": "eye1",
                     "type": "4eyes",
-                    "4eyes": "%s:2" % self.realm1,
+                    "4eyes": "{0!s}:2".format(self.realm1),
                     "separator": " "})
 
         r = check_serial_pass("eye1", "pin1password1 pin2password2")

--- a/tests/test_lib_tokens_hotp.py
+++ b/tests/test_lib_tokens_hotp.py
@@ -48,13 +48,13 @@ class HOTPTokenTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
 
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
 
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
 
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 

--- a/tests/test_lib_tokens_motp.py
+++ b/tests/test_lib_tokens_motp.py
@@ -39,13 +39,13 @@ class MotpTokenTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
 
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
 
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
 
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 
@@ -73,7 +73,7 @@ class MotpTokenTestCase(MyTestCase):
 
         # check pin+otp:
         token.set_pin(self.otppin)
-        r = token.authenticate("%saba73b" % self.otppin)
+        r = token.authenticate("{0!s}aba73b".format(self.otppin))
         self.assertTrue(r[0], r)
         self.assertTrue(r[1] == -1, r)
 
@@ -162,7 +162,7 @@ class MotpTokenTestCase(MyTestCase):
             otp = otps[i]
             sotp = motp1.calcOtp(e, key, pin)
 
-            self.assertTrue(sotp == otp, "%s==%s" % (sotp, otp))
+            self.assertTrue(sotp == otp, "{0!s}=={1!s}".format(sotp, otp))
             i += 1
 
     def test_06_reuse_otp_value(self):

--- a/tests/test_lib_tokens_passwordtoken.py
+++ b/tests/test_lib_tokens_passwordtoken.py
@@ -41,7 +41,7 @@ class PasswordTokenTestCase(MyTestCase):
 
         # check pin+otp:
         token.set_pin(self.serial1, "secretpin")
-        r = token.authenticate("secretpin%s" % self.password)
+        r = token.authenticate("secretpin{0!s}".format(self.password))
         self.assertTrue(r, r)
 
     def test_03_class_methods(self):

--- a/tests/test_lib_tokens_radius.py
+++ b/tests/test_lib_tokens_radius.py
@@ -87,7 +87,7 @@ class RadiusTokenTestCase(MyTestCase):
 
         info = token.get_class_info()
         self.assertTrue(info.get("title") == "RADIUS Token",
-                        "%s" % info.get("title"))
+                        "{0!s}".format(info.get("title")))
 
         info = token.get_class_info("title")
         self.assertTrue(info == "RADIUS Token", info)

--- a/tests/test_lib_tokens_remote.py
+++ b/tests/test_lib_tokens_remote.py
@@ -84,7 +84,7 @@ class RemoteTokenTestCase(MyTestCase):
 
         info = token.get_class_info()
         self.assertTrue(info.get("title") == "Remote Token",
-                        "%s" % info.get("title"))
+                        "{0!s}".format(info.get("title")))
 
         info = token.get_class_info("title")
         self.assertTrue(info == "Remote Token", info)

--- a/tests/test_lib_tokens_sms.py
+++ b/tests/test_lib_tokens_sms.py
@@ -62,13 +62,13 @@ class SMSTokenTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
 
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
 
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
 
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 
@@ -416,7 +416,7 @@ class SMSTokenTestCase(MyTestCase):
     def test_19_smstext(self):
         # create a SMSTEXT policy:
         p = set_policy(name="smstext",
-                       action="%s=%s" % (SMSACTION.SMSTEXT, "'Your <otp>'"),
+                       action="{0!s}={1!s}".format(SMSACTION.SMSTEXT, "'Your <otp>'"),
                        scope=SCOPE.AUTH)
         self.assertTrue(p > 0)
 

--- a/tests/test_lib_tokens_ssh.py
+++ b/tests/test_lib_tokens_ssh.py
@@ -58,7 +58,7 @@ RyMSQe4mn8oHJma2VzepBRBpLt7Q==
 
         info = token.get_class_info()
         self.assertTrue(info.get("title") == "SSHkey Token",
-                        "%s" % info.get("title"))
+                        "{0!s}".format(info.get("title")))
 
         info = token.get_class_info("title")
         self.assertTrue(info == "SSHkey Token", info)

--- a/tests/test_lib_tokens_tiqr.py
+++ b/tests/test_lib_tokens_tiqr.py
@@ -437,7 +437,7 @@ class TiQRTokenTestCase(MyTestCase):
 
         # First, send a wrong response
         req.all_data = {"response": "12345",
-                        "userId": "cornelius_%s" % self.realm1,
+                        "userId": "cornelius_{0!s}".format(self.realm1),
                         "sessionKey": session,
                         "operation": "login"}
         r = TiqrTokenClass.api_endpoint(req, g)
@@ -446,7 +446,7 @@ class TiQRTokenTestCase(MyTestCase):
 
         # Send the correct response
         req.all_data = {"response": response,
-                        "userId": "cornelius_%s" % self.realm1,
+                        "userId": "cornelius_{0!s}".format(self.realm1),
                         "sessionKey": session,
                         "operation": "login"}
         r = TiqrTokenClass.api_endpoint(req, g)
@@ -456,7 +456,7 @@ class TiQRTokenTestCase(MyTestCase):
         # Send the same response a second time would not work
         # since the Challenge is marked as answered
         req.all_data = {"response": response,
-                        "userId": "cornelius_%s" % self.realm1,
+                        "userId": "cornelius_{0!s}".format(self.realm1),
                         "sessionKey": session,
                         "operation": "login"}
         r = TiqrTokenClass.api_endpoint(req, g)

--- a/tests/test_lib_tokens_totp.py
+++ b/tests/test_lib_tokens_totp.py
@@ -58,13 +58,13 @@ class TOTPTokenTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
         
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
         
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
         
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
 

--- a/tests/test_lib_tokens_yubico.py
+++ b/tests/test_lib_tokens_yubico.py
@@ -52,7 +52,7 @@ status=REPLAYED_OTP"""
 
         info = token.get_class_info()
         self.assertTrue(info.get("title") == "Yubico Token",
-                        "%s" % info.get("title"))
+                        "{0!s}".format(info.get("title")))
 
         info = token.get_class_info("title")
         self.assertTrue(info == "Yubico Token", info)

--- a/tests/test_lib_tokens_yubikey.py
+++ b/tests/test_lib_tokens_yubikey.py
@@ -190,14 +190,14 @@ class YubikeyTokenTestCase(MyTestCase):
         nonce = "random nonce"
         apiid = "hallo"
         apikey = "1YMEbMZijD3DzL21UfKGnOOI13c="
-        set_privacyidea_config("yubikey.apiid.%s" % apiid, apikey)
+        set_privacyidea_config("yubikey.apiid.{0!s}".format(apiid), apikey)
         req.all_data = {'id': apiid,
                         "otp": otps[0],
                         "nonce": nonce}
         text_type, result = YubikeyTokenClass.api_endpoint(req, g)
         self.assertEqual(text_type, "plain")
         self.assertTrue("status=OK" in result, result)
-        self.assertTrue("nonce=%s" % nonce in result, result)
+        self.assertTrue("nonce={0!s}".format(nonce) in result, result)
 
     def test_98_wrong_tokenid(self):
         db_token = Token.query.filter(Token.serial == self.serial1).first()

--- a/tests/test_lib_user.py
+++ b/tests/test_lib_user.py
@@ -57,13 +57,13 @@ class UserTestCase(MyTestCase):
                     realm=self.realm1,
                     resolver=self.resolvername1)
         
-        user_str = "%s" % user
+        user_str = "{0!s}".format(user)
         self.assertTrue(user_str == "<root.resolver1@realm1>", user_str)
         
         self.assertFalse(user.is_empty())
         self.assertTrue(User().is_empty())
         
-        user_repr = "%r" % user
+        user_repr = "{0!r}".format(user)
         expected = "User(login='root', realm='realm1', resolver='resolver1')"
         self.assertTrue(user_repr == expected, user_repr)
         
@@ -190,7 +190,7 @@ class UserTestCase(MyTestCase):
         param = {"user": "cornelius",
                  "realm": self.realm2}
         user = get_user_from_param(param)
-        self.assertEqual("%s" % user, "<cornelius.resolver1@realm2>")
+        self.assertEqual("{0!s}".format(user), "<cornelius.resolver1@realm2>")
         
     def test_10_check_user_password(self):
         (added, failed) = set_realm("passwordrealm",

--- a/tests/test_resolver_realm.py
+++ b/tests/test_resolver_realm.py
@@ -58,7 +58,7 @@ class APIResolverTestCase(MyTestCase):
     def test_01_create_realm(self):
         realm = u"realm1"
         resolvers = u"r1, r2"
-        with self.app.test_request_context('/realm/%s' % realm,
+        with self.app.test_request_context('/realm/{0!s}'.format(realm),
                                            data={u"resolvers": resolvers},
                                            method='POST',
                                            headers={"Authorization": self.at}):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:privacyidea?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:privacyidea?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
